### PR TITLE
Correccion entrega unidad 01

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # disney-api
 Challenge preaceleración alkemy
+
+### Levantar container sql
+`docker run --name mysql -e MYSQL_DATABASE=disney -e MYSQL_ROOT_PASSWORD=root -p 3306:3306 -d mysql:latest`

--- a/pom.xml
+++ b/pom.xml
@@ -1,69 +1,73 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.5.4</version>
-		<relativePath/> <!-- lookup parent from repository -->
-	</parent>
-	<groupId>com.alkemy.disney</groupId>
-	<artifactId>disney</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
-	<name>disney</name>
-	<description>Api para explorar el mundo de Disney</description>
-	<properties>
-		<java.version>11</java.version>
-	</properties>
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-jpa</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>2.5.4</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <groupId>com.alkemy.disney</groupId>
+    <artifactId>disney</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>disney</name>
+    <description>Api para explorar el mundo de Disney</description>
+    <properties>
+        <java.version>11</java.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
 
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-devtools</artifactId>
-			<scope>runtime</scope>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
-			<groupId>mysql</groupId>
-			<artifactId>mysql-connector-java</artifactId>
-			<scope>runtime</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.projectlombok</groupId>
-			<artifactId>lombok</artifactId>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-devtools</artifactId>
+            <scope>runtime</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+    </dependencies>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-				<configuration>
-					<excludes>
-						<exclude>
-							<groupId>org.projectlombok</groupId>
-							<artifactId>lombok</artifactId>
-						</exclude>
-					</excludes>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.2</version>
+		<version>2.5.4</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.alkemy.disney</groupId>

--- a/src/main/java/com/alkemy/disney/disney/controller/GeneroController.java
+++ b/src/main/java/com/alkemy/disney/disney/controller/GeneroController.java
@@ -21,8 +21,6 @@ public class GeneroController {
     this.generoService = generoService;
   }
 
-
-
   @PostMapping
   public ResponseEntity<GeneroDTO> save(@RequestBody GeneroDTO genero) {
     GeneroDTO generoGuardado = generoService.save(genero);

--- a/src/main/java/com/alkemy/disney/disney/controller/GeneroController.java
+++ b/src/main/java/com/alkemy/disney/disney/controller/GeneroController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("genre")
 public class GeneroController {
 
-  private GeneroService generoService;
+  private final GeneroService generoService;
 
   @Autowired
   public GeneroController(GeneroService generoService) {

--- a/src/main/java/com/alkemy/disney/disney/controller/GeneroController.java
+++ b/src/main/java/com/alkemy/disney/disney/controller/GeneroController.java
@@ -13,8 +13,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("genre")
 public class GeneroController {
-  @Autowired
+
   private GeneroService generoService;
+
+  @Autowired
+  public GeneroController(GeneroService generoService) {
+    this.generoService = generoService;
+  }
+
+
 
   @PostMapping
   public ResponseEntity<GeneroDTO> save(@RequestBody GeneroDTO genero) {

--- a/src/main/java/com/alkemy/disney/disney/controller/GeneroController.java
+++ b/src/main/java/com/alkemy/disney/disney/controller/GeneroController.java
@@ -10,6 +10,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import javax.validation.Valid;
+
 @RestController
 @RequestMapping("genre")
 public class GeneroController {
@@ -22,7 +24,7 @@ public class GeneroController {
   }
 
   @PostMapping
-  public ResponseEntity<GeneroDTO> save(@RequestBody GeneroDTO genero) {
+  public ResponseEntity<GeneroDTO> save(@Valid @RequestBody GeneroDTO genero) {
     GeneroDTO generoGuardado = generoService.save(genero);
     return ResponseEntity.status(HttpStatus.CREATED).body(generoGuardado);
   }

--- a/src/main/java/com/alkemy/disney/disney/controller/GeneroController.java
+++ b/src/main/java/com/alkemy/disney/disney/controller/GeneroController.java
@@ -1,0 +1,24 @@
+package com.alkemy.disney.disney.controller;
+
+import com.alkemy.disney.disney.dto.GeneroDTO;
+import com.alkemy.disney.disney.service.GeneroService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("genre")
+public class GeneroController {
+  @Autowired
+  private GeneroService generoService;
+
+  @PostMapping
+  public ResponseEntity<GeneroDTO> save(@RequestBody GeneroDTO genero) {
+    GeneroDTO generoGuardado = generoService.save(genero);
+    return ResponseEntity.status(HttpStatus.CREATED).body(generoGuardado);
+  }
+}

--- a/src/main/java/com/alkemy/disney/disney/controller/PeliculaController.java
+++ b/src/main/java/com/alkemy/disney/disney/controller/PeliculaController.java
@@ -23,8 +23,10 @@ public class PeliculaController {
   }
 
   @GetMapping
-  public ResponseEntity<List<PeliculaBasicDTO>> getAll() {
-    List<PeliculaBasicDTO> dtos = peliculaService.getAll();
+  public ResponseEntity<List<PeliculaBasicDTO>> getAll(
+      @RequestParam(required = false) String name
+  ) {
+    List<PeliculaBasicDTO> dtos = peliculaService.getAll(name);
     return ResponseEntity.ok(dtos);
   }
 

--- a/src/main/java/com/alkemy/disney/disney/controller/PeliculaController.java
+++ b/src/main/java/com/alkemy/disney/disney/controller/PeliculaController.java
@@ -44,4 +44,11 @@ public class PeliculaController {
     this.peliculaService.delete(id);
     return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
   }
+
+  @PostMapping("{id}/character/{idPersonaje}")
+  public ResponseEntity<Void> addPersonaje(@PathVariable Long id, @PathVariable Long idPersonaje) {
+    this.peliculaService.addPersonaje(id, idPersonaje);
+    return ResponseEntity.status(HttpStatus.CREATED).build();
+  }
+
 }

--- a/src/main/java/com/alkemy/disney/disney/controller/PeliculaController.java
+++ b/src/main/java/com/alkemy/disney/disney/controller/PeliculaController.java
@@ -1,0 +1,29 @@
+package com.alkemy.disney.disney.controller;
+
+import com.alkemy.disney.disney.dto.PeliculaDTO;
+import com.alkemy.disney.disney.service.PeliculaService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("movies")
+public class PeliculaController {
+
+  private PeliculaService peliculaService;
+
+  @Autowired
+  public PeliculaController(PeliculaService peliculaService) {
+    this.peliculaService = peliculaService;
+  }
+
+  @PostMapping
+  public ResponseEntity<PeliculaDTO> save(@RequestBody PeliculaDTO pelicula) {
+    PeliculaDTO peliculaGuardada = peliculaService.save(pelicula);
+    return ResponseEntity.status(HttpStatus.CREATED).body(peliculaGuardada);
+  }
+}

--- a/src/main/java/com/alkemy/disney/disney/controller/PeliculaController.java
+++ b/src/main/java/com/alkemy/disney/disney/controller/PeliculaController.java
@@ -3,7 +3,6 @@ package com.alkemy.disney.disney.controller;
 import com.alkemy.disney.disney.dto.PeliculaBasicDTO;
 import com.alkemy.disney.disney.dto.PeliculaDTO;
 import com.alkemy.disney.disney.service.PeliculaService;
-import jdk.jfr.Frequency;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/alkemy/disney/disney/controller/PeliculaController.java
+++ b/src/main/java/com/alkemy/disney/disney/controller/PeliculaController.java
@@ -51,4 +51,10 @@ public class PeliculaController {
     return ResponseEntity.status(HttpStatus.CREATED).build();
   }
 
+  @DeleteMapping("{id}/character/{idPersonaje}")
+  public ResponseEntity<Void> removePersonaje(@PathVariable Long id, @PathVariable Long idPersonaje){
+    this.peliculaService.removePersonaje(id, idPersonaje);
+    return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+  }
+
 }

--- a/src/main/java/com/alkemy/disney/disney/controller/PeliculaController.java
+++ b/src/main/java/com/alkemy/disney/disney/controller/PeliculaController.java
@@ -14,7 +14,7 @@ import java.util.List;
 @RequestMapping("movies")
 public class PeliculaController {
 
-  private PeliculaService peliculaService;
+  private final PeliculaService peliculaService;
 
   @Autowired
   public PeliculaController(PeliculaService peliculaService) {

--- a/src/main/java/com/alkemy/disney/disney/controller/PeliculaController.java
+++ b/src/main/java/com/alkemy/disney/disney/controller/PeliculaController.java
@@ -2,6 +2,7 @@ package com.alkemy.disney.disney.controller;
 
 import com.alkemy.disney.disney.dto.PeliculaBasicDTO;
 import com.alkemy.disney.disney.dto.PeliculaDTO;
+import com.alkemy.disney.disney.dto.PersonajeDTO;
 import com.alkemy.disney.disney.service.PeliculaService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -38,6 +39,12 @@ public class PeliculaController {
   public ResponseEntity<PeliculaDTO> save(@Valid @RequestBody PeliculaDTO pelicula) {
     PeliculaDTO peliculaGuardada = peliculaService.save(pelicula);
     return ResponseEntity.status(HttpStatus.CREATED).body(peliculaGuardada);
+  }
+
+  @PutMapping("{id}")
+  public ResponseEntity<PeliculaDTO> update(@PathVariable Long id, @RequestBody PeliculaDTO pelicula) {
+    PeliculaDTO res = this.peliculaService.update(id, pelicula);
+    return ResponseEntity.ok().body(res);
   }
 
   @DeleteMapping("{id}")

--- a/src/main/java/com/alkemy/disney/disney/controller/PeliculaController.java
+++ b/src/main/java/com/alkemy/disney/disney/controller/PeliculaController.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
 import java.util.List;
 
 @RestController
@@ -34,7 +35,7 @@ public class PeliculaController {
   }
 
   @PostMapping
-  public ResponseEntity<PeliculaDTO> save(@RequestBody PeliculaDTO pelicula) {
+  public ResponseEntity<PeliculaDTO> save(@Valid @RequestBody PeliculaDTO pelicula) {
     PeliculaDTO peliculaGuardada = peliculaService.save(pelicula);
     return ResponseEntity.status(HttpStatus.CREATED).body(peliculaGuardada);
   }

--- a/src/main/java/com/alkemy/disney/disney/controller/PeliculaController.java
+++ b/src/main/java/com/alkemy/disney/disney/controller/PeliculaController.java
@@ -3,6 +3,7 @@ package com.alkemy.disney.disney.controller;
 import com.alkemy.disney.disney.dto.PeliculaBasicDTO;
 import com.alkemy.disney.disney.dto.PeliculaDTO;
 import com.alkemy.disney.disney.service.PeliculaService;
+import jdk.jfr.Frequency;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -25,9 +26,10 @@ public class PeliculaController {
   @GetMapping
   public ResponseEntity<List<PeliculaBasicDTO>> getAll(
       @RequestParam(required = false) String name,
-      @RequestParam(required = false) Long idGenre
+      @RequestParam(required = false) Long idGenre,
+      @RequestParam(defaultValue = "ASC") String order
   ) {
-    List<PeliculaBasicDTO> dtos = peliculaService.getAll(name, idGenre);
+    List<PeliculaBasicDTO> dtos = peliculaService.getAll(name, idGenre, order);
     return ResponseEntity.ok(dtos);
   }
 

--- a/src/main/java/com/alkemy/disney/disney/controller/PeliculaController.java
+++ b/src/main/java/com/alkemy/disney/disney/controller/PeliculaController.java
@@ -1,14 +1,14 @@
 package com.alkemy.disney.disney.controller;
 
+import com.alkemy.disney.disney.dto.PeliculaBasicDTO;
 import com.alkemy.disney.disney.dto.PeliculaDTO;
 import com.alkemy.disney.disney.service.PeliculaService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("movies")
@@ -19,6 +19,12 @@ public class PeliculaController {
   @Autowired
   public PeliculaController(PeliculaService peliculaService) {
     this.peliculaService = peliculaService;
+  }
+
+  @GetMapping
+  public ResponseEntity<List<PeliculaBasicDTO>> getAll() {
+    List<PeliculaBasicDTO> dtos = peliculaService.getAll();
+    return ResponseEntity.ok(dtos);
   }
 
   @PostMapping

--- a/src/main/java/com/alkemy/disney/disney/controller/PeliculaController.java
+++ b/src/main/java/com/alkemy/disney/disney/controller/PeliculaController.java
@@ -24,9 +24,10 @@ public class PeliculaController {
 
   @GetMapping
   public ResponseEntity<List<PeliculaBasicDTO>> getAll(
-      @RequestParam(required = false) String name
+      @RequestParam(required = false) String name,
+      @RequestParam(required = false) Long idGenre
   ) {
-    List<PeliculaBasicDTO> dtos = peliculaService.getAll(name);
+    List<PeliculaBasicDTO> dtos = peliculaService.getAll(name, idGenre);
     return ResponseEntity.ok(dtos);
   }
 

--- a/src/main/java/com/alkemy/disney/disney/controller/PeliculaController.java
+++ b/src/main/java/com/alkemy/disney/disney/controller/PeliculaController.java
@@ -27,6 +27,12 @@ public class PeliculaController {
     return ResponseEntity.ok(dtos);
   }
 
+  @GetMapping("{id}")
+  public ResponseEntity<PeliculaDTO> getDetailsById(@PathVariable Long id) {
+    PeliculaDTO dto = peliculaService.getDetailsById(id);
+    return ResponseEntity.ok(dto);
+  }
+
   @PostMapping
   public ResponseEntity<PeliculaDTO> save(@RequestBody PeliculaDTO pelicula) {
     PeliculaDTO peliculaGuardada = peliculaService.save(pelicula);

--- a/src/main/java/com/alkemy/disney/disney/controller/PeliculaController.java
+++ b/src/main/java/com/alkemy/disney/disney/controller/PeliculaController.java
@@ -38,4 +38,10 @@ public class PeliculaController {
     PeliculaDTO peliculaGuardada = peliculaService.save(pelicula);
     return ResponseEntity.status(HttpStatus.CREATED).body(peliculaGuardada);
   }
+
+  @DeleteMapping("{id}")
+  public ResponseEntity<Void> delete(@PathVariable Long id) {
+    this.peliculaService.delete(id);
+    return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+  }
 }

--- a/src/main/java/com/alkemy/disney/disney/controller/PeliculaController.java
+++ b/src/main/java/com/alkemy/disney/disney/controller/PeliculaController.java
@@ -2,7 +2,6 @@ package com.alkemy.disney.disney.controller;
 
 import com.alkemy.disney.disney.dto.PeliculaBasicDTO;
 import com.alkemy.disney.disney.dto.PeliculaDTO;
-import com.alkemy.disney.disney.dto.PersonajeDTO;
 import com.alkemy.disney.disney.service.PeliculaService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -60,7 +59,7 @@ public class PeliculaController {
   }
 
   @DeleteMapping("{id}/character/{idPersonaje}")
-  public ResponseEntity<Void> removePersonaje(@PathVariable Long id, @PathVariable Long idPersonaje){
+  public ResponseEntity<Void> removePersonaje(@PathVariable Long id, @PathVariable Long idPersonaje) {
     this.peliculaService.removePersonaje(id, idPersonaje);
     return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
   }

--- a/src/main/java/com/alkemy/disney/disney/controller/PersonajeController.java
+++ b/src/main/java/com/alkemy/disney/disney/controller/PersonajeController.java
@@ -38,4 +38,10 @@ public class PersonajeController {
     PersonajeDTO personajeGuardado = personajeService.save(personaje);
     return ResponseEntity.status(HttpStatus.CREATED).body(personajeGuardado);
   }
+
+  @PutMapping("{id}")
+  public ResponseEntity<PersonajeDTO> update(@PathVariable Long id,@RequestBody PersonajeDTO personaje) {
+    PersonajeDTO res = this.personajeService.update(id, personaje);
+    return ResponseEntity.ok().body(res);
+  }
 }

--- a/src/main/java/com/alkemy/disney/disney/controller/PersonajeController.java
+++ b/src/main/java/com/alkemy/disney/disney/controller/PersonajeController.java
@@ -23,9 +23,10 @@ public class PersonajeController {
 
   @GetMapping
   public ResponseEntity<List<PersonajeBasicDTO>> getAll(
-      @RequestParam(required = false) String name
+      @RequestParam(required = false) String name,
+      @RequestParam(required = false) Integer age
   ) {
-    List<PersonajeBasicDTO> personajes = this.personajeService.getAll(name);
+    List<PersonajeBasicDTO> personajes = this.personajeService.getAll(name, age);
     return ResponseEntity.ok(personajes);
   }
 

--- a/src/main/java/com/alkemy/disney/disney/controller/PersonajeController.java
+++ b/src/main/java/com/alkemy/disney/disney/controller/PersonajeController.java
@@ -40,7 +40,7 @@ public class PersonajeController {
   }
 
   @PutMapping("{id}")
-  public ResponseEntity<PersonajeDTO> update(@PathVariable Long id,@RequestBody PersonajeDTO personaje) {
+  public ResponseEntity<PersonajeDTO> update(@PathVariable Long id, @RequestBody PersonajeDTO personaje) {
     PersonajeDTO res = this.personajeService.update(id, personaje);
     return ResponseEntity.ok().body(res);
   }

--- a/src/main/java/com/alkemy/disney/disney/controller/PersonajeController.java
+++ b/src/main/java/com/alkemy/disney/disney/controller/PersonajeController.java
@@ -22,8 +22,10 @@ public class PersonajeController {
   }
 
   @GetMapping
-  public ResponseEntity<List<PersonajeBasicDTO>> getAll() {
-    List<PersonajeBasicDTO> personajes = this.personajeService.getAll();
+  public ResponseEntity<List<PersonajeBasicDTO>> getAll(
+      @RequestParam(required = false) String name
+  ) {
+    List<PersonajeBasicDTO> personajes = this.personajeService.getAll(name);
     return ResponseEntity.ok(personajes);
   }
 

--- a/src/main/java/com/alkemy/disney/disney/controller/PersonajeController.java
+++ b/src/main/java/com/alkemy/disney/disney/controller/PersonajeController.java
@@ -24,9 +24,10 @@ public class PersonajeController {
   @GetMapping
   public ResponseEntity<List<PersonajeBasicDTO>> getAll(
       @RequestParam(required = false) String name,
-      @RequestParam(required = false) Integer age
+      @RequestParam(required = false) Integer age,
+      @RequestParam(required = false) List<Long> movies
   ) {
-    List<PersonajeBasicDTO> personajes = this.personajeService.getAll(name, age);
+    List<PersonajeBasicDTO> personajes = this.personajeService.getAll(name, age, movies);
     return ResponseEntity.ok(personajes);
   }
 

--- a/src/main/java/com/alkemy/disney/disney/controller/PersonajeController.java
+++ b/src/main/java/com/alkemy/disney/disney/controller/PersonajeController.java
@@ -44,4 +44,10 @@ public class PersonajeController {
     PersonajeDTO res = this.personajeService.update(id, personaje);
     return ResponseEntity.ok().body(res);
   }
+
+  @DeleteMapping("{id}")
+  public ResponseEntity<Void> delete(@PathVariable Long id) {
+    this.personajeService.delete(id);
+    return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+  }
 }

--- a/src/main/java/com/alkemy/disney/disney/controller/PersonajeController.java
+++ b/src/main/java/com/alkemy/disney/disney/controller/PersonajeController.java
@@ -1,0 +1,29 @@
+package com.alkemy.disney.disney.controller;
+
+import com.alkemy.disney.disney.dto.PersonajeDTO;
+import com.alkemy.disney.disney.service.PersonajeService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/characters")
+public class PersonajeController {
+
+  PersonajeService personajeService;
+
+  @Autowired
+  public PersonajeController(PersonajeService personajeService) {
+    this.personajeService = personajeService;
+  }
+
+  @PostMapping
+  public ResponseEntity<PersonajeDTO> save(@RequestBody PersonajeDTO personaje) {
+    PersonajeDTO personajeGuardado = personajeService.save(personaje);
+    return ResponseEntity.status(HttpStatus.CREATED).body(personajeGuardado);
+  }
+}

--- a/src/main/java/com/alkemy/disney/disney/controller/PersonajeController.java
+++ b/src/main/java/com/alkemy/disney/disney/controller/PersonajeController.java
@@ -1,14 +1,14 @@
 package com.alkemy.disney.disney.controller;
 
+import com.alkemy.disney.disney.dto.PersonajeBasicDTO;
 import com.alkemy.disney.disney.dto.PersonajeDTO;
 import com.alkemy.disney.disney.service.PersonajeService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/characters")
@@ -19,6 +19,12 @@ public class PersonajeController {
   @Autowired
   public PersonajeController(PersonajeService personajeService) {
     this.personajeService = personajeService;
+  }
+
+  @GetMapping
+  public ResponseEntity<List<PersonajeBasicDTO>> getAll() {
+    List<PersonajeBasicDTO> personajes = this.personajeService.getAll();
+    return ResponseEntity.ok(personajes);
   }
 
   @PostMapping

--- a/src/main/java/com/alkemy/disney/disney/controller/PersonajeController.java
+++ b/src/main/java/com/alkemy/disney/disney/controller/PersonajeController.java
@@ -50,10 +50,4 @@ public class PersonajeController {
     this.personajeService.delete(id);
     return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
   }
-
- @PostMapping("{id}/movie/{idPelicula}")
-  public ResponseEntity<Void> addPelicula(@PathVariable Long id, @PathVariable Long idPelicula) {
-  this.personajeService.addPelicula(id, idPelicula);
-  return ResponseEntity.status(HttpStatus.CREATED).build();
- }
 }

--- a/src/main/java/com/alkemy/disney/disney/controller/PersonajeController.java
+++ b/src/main/java/com/alkemy/disney/disney/controller/PersonajeController.java
@@ -50,4 +50,10 @@ public class PersonajeController {
     this.personajeService.delete(id);
     return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
   }
+
+ @PostMapping("{id}/movie/{idPelicula}")
+  public ResponseEntity<Void> addPelicula(@PathVariable Long id, @PathVariable Long idPelicula) {
+  this.personajeService.addPelicula(id, idPelicula);
+  return ResponseEntity.status(HttpStatus.CREATED).build();
+ }
 }

--- a/src/main/java/com/alkemy/disney/disney/controller/PersonajeController.java
+++ b/src/main/java/com/alkemy/disney/disney/controller/PersonajeController.java
@@ -27,6 +27,12 @@ public class PersonajeController {
     return ResponseEntity.ok(personajes);
   }
 
+  @GetMapping("/{id}")
+  public ResponseEntity<PersonajeDTO> getDetailsById(@PathVariable Long id) {
+    PersonajeDTO personaje = personajeService.getDetailsById(id);
+    return ResponseEntity.ok(personaje);
+  }
+
   @PostMapping
   public ResponseEntity<PersonajeDTO> save(@RequestBody PersonajeDTO personaje) {
     PersonajeDTO personajeGuardado = personajeService.save(personaje);

--- a/src/main/java/com/alkemy/disney/disney/controller/RestExceptionHandler.java
+++ b/src/main/java/com/alkemy/disney/disney/controller/RestExceptionHandler.java
@@ -1,0 +1,60 @@
+package com.alkemy.disney.disney.controller;
+
+
+import com.alkemy.disney.disney.dto.ApiErrorDTO;
+import com.alkemy.disney.disney.exception.ParamNotFound;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.validation.ObjectError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@ControllerAdvice
+public class RestExceptionHandler extends ResponseEntityExceptionHandler {
+
+  @ExceptionHandler(value = {ParamNotFound.class})
+  protected ResponseEntity<Object> handleParamNotFound(RuntimeException ex, WebRequest request) {
+    ApiErrorDTO errorDTO = new ApiErrorDTO(
+        HttpStatus.BAD_REQUEST,
+        ex.getMessage(),
+        List.of("Param Not Found")
+    );
+    return handleExceptionInternal(ex, errorDTO, new HttpHeaders(), HttpStatus.BAD_REQUEST, request);
+  }
+
+  @Override
+  protected ResponseEntity<Object> handleMethodArgumentNotValid(
+      MethodArgumentNotValidException ex,
+      HttpHeaders headers,
+      HttpStatus status,
+      WebRequest request) {
+    List<String> errors = new ArrayList<>();
+
+    for (FieldError error : ex.getBindingResult().getFieldErrors()) {
+      errors.add(error.getField() + ": " + error.getDefaultMessage());
+
+    }
+    for (ObjectError error : ex.getBindingResult().getGlobalErrors()) {
+      errors.add(error.getObjectName() + ": " + error.getDefaultMessage());
+    }
+
+    ApiErrorDTO apiError = new ApiErrorDTO(HttpStatus.BAD_REQUEST, ex.getLocalizedMessage(), errors);
+    return handleExceptionInternal(
+        ex, apiError, headers, apiError.getStatus(), request);
+  }
+
+  @ExceptionHandler(value = {IllegalArgumentException.class, IllegalStateException.class})
+  public ResponseEntity<Object> handleConflict(RuntimeException ex, WebRequest request) {
+    String bodyOfResponse = "This should be application specific";
+    return handleExceptionInternal(ex, bodyOfResponse, new HttpHeaders(), HttpStatus.CONFLICT, request);
+  }
+
+}

--- a/src/main/java/com/alkemy/disney/disney/dto/ApiErrorDTO.java
+++ b/src/main/java/com/alkemy/disney/disney/dto/ApiErrorDTO.java
@@ -1,0 +1,17 @@
+package com.alkemy.disney.disney.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.springframework.http.HttpStatus;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class ApiErrorDTO {
+
+  private HttpStatus status;
+  private String message;
+  private List<String> errors;
+
+}

--- a/src/main/java/com/alkemy/disney/disney/dto/GeneroDTO.java
+++ b/src/main/java/com/alkemy/disney/disney/dto/GeneroDTO.java
@@ -1,0 +1,12 @@
+package com.alkemy.disney.disney.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class GeneroDTO {
+  private Long id;
+  private String nombre;
+  private String imagen;
+}

--- a/src/main/java/com/alkemy/disney/disney/dto/GeneroDTO.java
+++ b/src/main/java/com/alkemy/disney/disney/dto/GeneroDTO.java
@@ -3,10 +3,16 @@ package com.alkemy.disney.disney.dto;
 import lombok.Getter;
 import lombok.Setter;
 
+import javax.validation.constraints.NotBlank;
+
 @Setter
 @Getter
 public class GeneroDTO {
   private Long id;
+
+  @NotBlank(message = "Nombre es requerido")
   private String nombre;
+
+  @NotBlank(message = "Imagen es requerido")
   private String imagen;
 }

--- a/src/main/java/com/alkemy/disney/disney/dto/PeliculaBasicDTO.java
+++ b/src/main/java/com/alkemy/disney/disney/dto/PeliculaBasicDTO.java
@@ -1,0 +1,14 @@
+package com.alkemy.disney.disney.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+public class PeliculaBasicDTO {
+  private String imagen;
+  private String titulo;
+  private LocalDate fechaDeCreacion;
+}

--- a/src/main/java/com/alkemy/disney/disney/dto/PeliculaDTO.java
+++ b/src/main/java/com/alkemy/disney/disney/dto/PeliculaDTO.java
@@ -1,7 +1,6 @@
 package com.alkemy.disney.disney.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.validator.constraints.Range;

--- a/src/main/java/com/alkemy/disney/disney/dto/PeliculaDTO.java
+++ b/src/main/java/com/alkemy/disney/disney/dto/PeliculaDTO.java
@@ -1,0 +1,19 @@
+package com.alkemy.disney.disney.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Setter
+public class PeliculaDTO {
+  private Long id;
+  private String imagen;
+  private String titulo;
+  private LocalDate fechaDeCreacion;
+  private Integer calificacion;
+  private List<PersonajeDTO> personajes;
+  private Long generoId;
+}

--- a/src/main/java/com/alkemy/disney/disney/dto/PeliculaDTO.java
+++ b/src/main/java/com/alkemy/disney/disney/dto/PeliculaDTO.java
@@ -2,7 +2,10 @@ package com.alkemy.disney.disney.dto;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.validator.constraints.Range;
 
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -10,10 +13,20 @@ import java.util.List;
 @Setter
 public class PeliculaDTO {
   private Long id;
+
+  @NotBlank(message = "Image is mandatory")
   private String imagen;
+
+  @NotBlank(message = "Image is mandatory")
   private String titulo;
+
   private LocalDate fechaDeCreacion;
+
+  @NotNull(message = "Rango es mandatorio")
+  @Range(max = 5, message = "Rango no valido")
   private Integer calificacion;
+
   private List<PersonajeDTO> personajes;
+
   private Long generoId;
 }

--- a/src/main/java/com/alkemy/disney/disney/dto/PeliculaDTO.java
+++ b/src/main/java/com/alkemy/disney/disney/dto/PeliculaDTO.java
@@ -1,5 +1,7 @@
 package com.alkemy.disney.disney.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.validator.constraints.Range;
@@ -20,6 +22,7 @@ public class PeliculaDTO {
   @NotBlank(message = "Image is mandatory")
   private String titulo;
 
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd-MM-yyyy")
   private LocalDate fechaDeCreacion;
 
   @NotNull(message = "Rango es mandatorio")

--- a/src/main/java/com/alkemy/disney/disney/dto/PeliculaFilterDTO.java
+++ b/src/main/java/com/alkemy/disney/disney/dto/PeliculaFilterDTO.java
@@ -9,4 +9,5 @@ import lombok.Setter;
 @AllArgsConstructor
 public class PeliculaFilterDTO {
   private String name;
+  private Long idGenre;
 }

--- a/src/main/java/com/alkemy/disney/disney/dto/PeliculaFilterDTO.java
+++ b/src/main/java/com/alkemy/disney/disney/dto/PeliculaFilterDTO.java
@@ -4,8 +4,6 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 
-import java.util.Locale;
-
 @Getter
 @Setter
 @AllArgsConstructor
@@ -15,11 +13,6 @@ public class PeliculaFilterDTO {
   private String order;
 
   public boolean isAsc() {
-//    return order.toLowerCase(Locale.ROOT).equals("asc");
     return order.compareToIgnoreCase("ASC") == 0;
-  }
-
-  public boolean isDesc() {
-    return order.toLowerCase(Locale.ROOT).equals("desc");
   }
 }

--- a/src/main/java/com/alkemy/disney/disney/dto/PeliculaFilterDTO.java
+++ b/src/main/java/com/alkemy/disney/disney/dto/PeliculaFilterDTO.java
@@ -1,0 +1,12 @@
+package com.alkemy.disney.disney.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class PeliculaFilterDTO {
+  private String name;
+}

--- a/src/main/java/com/alkemy/disney/disney/dto/PeliculaFilterDTO.java
+++ b/src/main/java/com/alkemy/disney/disney/dto/PeliculaFilterDTO.java
@@ -4,10 +4,22 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.Locale;
+
 @Getter
 @Setter
 @AllArgsConstructor
 public class PeliculaFilterDTO {
   private String name;
   private Long idGenre;
+  private String order;
+
+  public boolean isAsc() {
+//    return order.toLowerCase(Locale.ROOT).equals("asc");
+    return order.compareToIgnoreCase("ASC") == 0;
+  }
+
+  public boolean isDesc() {
+    return order.toLowerCase(Locale.ROOT).equals("desc");
+  }
 }

--- a/src/main/java/com/alkemy/disney/disney/dto/PersonajeBasicDTO.java
+++ b/src/main/java/com/alkemy/disney/disney/dto/PersonajeBasicDTO.java
@@ -1,0 +1,11 @@
+package com.alkemy.disney.disney.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class PersonajeBasicDTO {
+  private String imagen;
+  private String nombre;
+}

--- a/src/main/java/com/alkemy/disney/disney/dto/PersonajeDTO.java
+++ b/src/main/java/com/alkemy/disney/disney/dto/PersonajeDTO.java
@@ -1,0 +1,18 @@
+package com.alkemy.disney.disney.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class PersonajeDTO {
+  private Long id;
+  private String imagen;
+  private String nombre;
+  private Integer edad;
+  private Float peso;
+  private String historia;
+  private List<PeliculaDTO> peliculas;
+}

--- a/src/main/java/com/alkemy/disney/disney/dto/PersonajeFilterDTO.java
+++ b/src/main/java/com/alkemy/disney/disney/dto/PersonajeFilterDTO.java
@@ -1,0 +1,11 @@
+package com.alkemy.disney.disney.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+@AllArgsConstructor
+public class PersonajeFilterDTO {
+  private String name;
+}

--- a/src/main/java/com/alkemy/disney/disney/dto/PersonajeFilterDTO.java
+++ b/src/main/java/com/alkemy/disney/disney/dto/PersonajeFilterDTO.java
@@ -4,9 +4,13 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 
-@Getter @Setter
+import java.util.List;
+
+@Getter
+@Setter
 @AllArgsConstructor
 public class PersonajeFilterDTO {
   private String name;
   private Integer edad;
+  private List<Long> idMovies;
 }

--- a/src/main/java/com/alkemy/disney/disney/dto/PersonajeFilterDTO.java
+++ b/src/main/java/com/alkemy/disney/disney/dto/PersonajeFilterDTO.java
@@ -8,4 +8,5 @@ import lombok.Setter;
 @AllArgsConstructor
 public class PersonajeFilterDTO {
   private String name;
+  private Integer edad;
 }

--- a/src/main/java/com/alkemy/disney/disney/entity/PeliculaEntity.java
+++ b/src/main/java/com/alkemy/disney/disney/entity/PeliculaEntity.java
@@ -43,12 +43,17 @@ public class PeliculaEntity {
   private Set<PersonajeEntity> personajes = new HashSet<>();
 
   // TODO: ver cascade
-  @ManyToOne(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
+  @ManyToOne(fetch = FetchType.EAGER)
   @JoinColumn(name = "genero_id", insertable = false, updatable = false)
   private GeneroEntity genero;
 
+  // TODO: ver nullable
   @Column(name = "genero_id", nullable = false)
   private Long generoId;
 
   private boolean deleted = Boolean.FALSE;
+
+  public void addPersonaje(PersonajeEntity personaje) {
+    personajes.add(personaje);
+  }
 }

--- a/src/main/java/com/alkemy/disney/disney/entity/PeliculaEntity.java
+++ b/src/main/java/com/alkemy/disney/disney/entity/PeliculaEntity.java
@@ -56,4 +56,8 @@ public class PeliculaEntity {
   public void addPersonaje(PersonajeEntity personaje) {
     personajes.add(personaje);
   }
+
+  public void removePersonaje(PersonajeEntity personaje) {
+    personajes.remove(personaje);
+  }
 }

--- a/src/main/java/com/alkemy/disney/disney/entity/PeliculaEntity.java
+++ b/src/main/java/com/alkemy/disney/disney/entity/PeliculaEntity.java
@@ -3,6 +3,8 @@ package com.alkemy.disney.disney.entity;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import javax.persistence.*;
 import java.time.LocalDate;
@@ -13,6 +15,8 @@ import java.util.Set;
 @Table(name = "pelicula")
 @Getter
 @Setter
+@SQLDelete(sql = "UPDATE pelicula SET deleted = true WHERE id=?")
+@Where(clause = "deleted=false")
 public class PeliculaEntity {
   @Id
   @GeneratedValue(strategy = GenerationType.SEQUENCE)
@@ -45,4 +49,6 @@ public class PeliculaEntity {
 
   @Column(name = "genero_id", nullable = false)
   private Long generoId;
+
+  private boolean deleted = Boolean.FALSE;
 }

--- a/src/main/java/com/alkemy/disney/disney/entity/PeliculaEntity.java
+++ b/src/main/java/com/alkemy/disney/disney/entity/PeliculaEntity.java
@@ -43,7 +43,8 @@ public class PeliculaEntity {
   )
   private Set<PersonajeEntity> personajes = new HashSet<>();
 
-  @ManyToOne(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
+  // TODO: ver cascade
+  @ManyToOne(fetch = FetchType.EAGER)
   @JoinColumn(name = "genero_id", insertable = false, updatable = false)
   private GeneroEntity genero;
 

--- a/src/main/java/com/alkemy/disney/disney/entity/PeliculaEntity.java
+++ b/src/main/java/com/alkemy/disney/disney/entity/PeliculaEntity.java
@@ -39,12 +39,11 @@ public class PeliculaEntity {
   @JoinTable(
       name = "pelicula_personaje",
       joinColumns = @JoinColumn(name = "pelicula_id"),
-      inverseJoinColumns = @JoinColumn(name = "personaje_id")
-  )
+      inverseJoinColumns = @JoinColumn(name = "personaje_id"))
   private Set<PersonajeEntity> personajes = new HashSet<>();
 
   // TODO: ver cascade
-  @ManyToOne(fetch = FetchType.EAGER)
+  @ManyToOne(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
   @JoinColumn(name = "genero_id", insertable = false, updatable = false)
   private GeneroEntity genero;
 

--- a/src/main/java/com/alkemy/disney/disney/entity/PersonajeEntity.java
+++ b/src/main/java/com/alkemy/disney/disney/entity/PersonajeEntity.java
@@ -2,6 +2,8 @@ package com.alkemy.disney.disney.entity;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import javax.persistence.*;
 import java.util.HashSet;
@@ -11,6 +13,8 @@ import java.util.Set;
 @Table(name = "personaje")
 @Getter
 @Setter
+@SQLDelete(sql = "UPDATE personaje SET deleted = true WHERE id=?")
+@Where(clause = "deleted=false")
 public class PersonajeEntity {
   @Id
   @GeneratedValue(strategy = GenerationType.SEQUENCE)
@@ -28,6 +32,8 @@ public class PersonajeEntity {
 
   @ManyToMany(mappedBy = "personajes", cascade = CascadeType.ALL)
   private Set<PeliculaEntity> peliculas = new HashSet<>();
+
+  private boolean deleted = Boolean.FALSE;
 
   public void agregarPelicula(PeliculaEntity pelicula) {
     this.peliculas.add(pelicula);

--- a/src/main/java/com/alkemy/disney/disney/entity/PersonajeEntity.java
+++ b/src/main/java/com/alkemy/disney/disney/entity/PersonajeEntity.java
@@ -35,11 +35,4 @@ public class PersonajeEntity {
 
   private boolean deleted = Boolean.FALSE;
 
-  public void agregarPelicula(PeliculaEntity pelicula) {
-    this.peliculas.add(pelicula);
-  }
-
-  public void eliminarPelicula(PeliculaEntity pelicula) {
-    this.peliculas.remove(pelicula);
-  }
 }

--- a/src/main/java/com/alkemy/disney/disney/exception/ParamNotFound.java
+++ b/src/main/java/com/alkemy/disney/disney/exception/ParamNotFound.java
@@ -1,0 +1,7 @@
+package com.alkemy.disney.disney.exception;
+
+public class ParamNotFound extends RuntimeException {
+  public ParamNotFound(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/alkemy/disney/disney/mapper/GeneroMapper.java
+++ b/src/main/java/com/alkemy/disney/disney/mapper/GeneroMapper.java
@@ -1,0 +1,23 @@
+package com.alkemy.disney.disney.mapper;
+
+import com.alkemy.disney.disney.dto.GeneroDTO;
+import com.alkemy.disney.disney.entity.GeneroEntity;
+import org.springframework.stereotype.Component;
+
+@Component
+public class GeneroMapper {
+  public GeneroEntity generoDTO2Entity(GeneroDTO dto) {
+    GeneroEntity entity = new GeneroEntity();
+    entity.setImagen(dto.getImagen());
+    entity.setNombre(dto.getNombre());
+    return entity;
+  }
+
+  public GeneroDTO generoEntity2DTO(GeneroEntity entity) {
+    GeneroDTO dto = new GeneroDTO();
+    dto.setId(entity.getId());
+    dto.setImagen(entity.getImagen());
+    dto.setNombre(entity.getNombre());
+    return dto;
+  }
+}

--- a/src/main/java/com/alkemy/disney/disney/mapper/PeliculaMapper.java
+++ b/src/main/java/com/alkemy/disney/disney/mapper/PeliculaMapper.java
@@ -65,4 +65,12 @@ public class PeliculaMapper {
     }
     return dtos;
   }
+
+  public void peliculaEntityRefreshValues(PeliculaEntity entity, PeliculaDTO peliculaDTO) {
+    entity.setImagen(peliculaDTO.getImagen());
+    entity.setTitulo(peliculaDTO.getTitulo());
+    entity.setFechaDeCreacion(peliculaDTO.getFechaDeCreacion());
+    entity.setCalificacion(peliculaDTO.getCalificacion());
+    entity.setGeneroId(entity.getGeneroId());
+  }
 }

--- a/src/main/java/com/alkemy/disney/disney/mapper/PeliculaMapper.java
+++ b/src/main/java/com/alkemy/disney/disney/mapper/PeliculaMapper.java
@@ -1,5 +1,6 @@
 package com.alkemy.disney.disney.mapper;
 
+import com.alkemy.disney.disney.dto.PeliculaBasicDTO;
 import com.alkemy.disney.disney.dto.PeliculaDTO;
 import com.alkemy.disney.disney.dto.PersonajeDTO;
 import com.alkemy.disney.disney.entity.PeliculaEntity;
@@ -49,6 +50,19 @@ public class PeliculaMapper {
   public List<PeliculaDTO> peliculaEntityList2DTOList(Set<PeliculaEntity> entities, boolean loadPersonajes) {
     List<PeliculaDTO> dtos = new ArrayList<>();
     entities.forEach(entity -> dtos.add(this.peliculaEntity2DTO(entity, loadPersonajes)));
+    return dtos;
+  }
+
+  public List<PeliculaBasicDTO> pelicualEntityList2BasicDTOList(List<PeliculaEntity> entities) {
+    List<PeliculaBasicDTO> dtos = new ArrayList<>();
+    PeliculaBasicDTO basicDTO;
+    for (PeliculaEntity entity : entities) {
+      basicDTO = new PeliculaBasicDTO();
+      basicDTO.setImagen(entity.getImagen());
+      basicDTO.setTitulo(entity.getTitulo());
+      basicDTO.setFechaDeCreacion(entity.getFechaDeCreacion());
+      dtos.add(basicDTO);
+    }
     return dtos;
   }
 }

--- a/src/main/java/com/alkemy/disney/disney/mapper/PeliculaMapper.java
+++ b/src/main/java/com/alkemy/disney/disney/mapper/PeliculaMapper.java
@@ -1,0 +1,54 @@
+package com.alkemy.disney.disney.mapper;
+
+import com.alkemy.disney.disney.dto.PeliculaDTO;
+import com.alkemy.disney.disney.dto.PersonajeDTO;
+import com.alkemy.disney.disney.entity.PeliculaEntity;
+import com.alkemy.disney.disney.entity.PersonajeEntity;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+@Component
+public class PeliculaMapper {
+
+  @Autowired
+  private PersonajeMapper personajeMapper;
+
+  public PeliculaEntity peliculaDTO2Entity(PeliculaDTO dto) {
+    PeliculaEntity entity = new PeliculaEntity();
+    entity.setImagen(dto.getImagen());
+    entity.setTitulo(dto.getTitulo());
+    entity.setCalificacion(dto.getCalificacion());
+    entity.setFechaDeCreacion(dto.getFechaDeCreacion());
+    entity.setGeneroId(dto.getGeneroId());
+    // personajes
+    Set<PersonajeEntity> personajes = this.personajeMapper.personajeDTOList2Entity(dto.getPersonajes());
+    entity.setPersonajes(personajes);
+    return entity;
+  }
+
+  public PeliculaDTO peliculaEntity2DTO(PeliculaEntity entity, boolean loadPersonajes) {
+    PeliculaDTO dto = new PeliculaDTO();
+    dto.setFechaDeCreacion(entity.getFechaDeCreacion());
+    dto.setId(entity.getId());
+    dto.setImagen(entity.getImagen());
+    dto.setTitulo(entity.getTitulo());
+    dto.setFechaDeCreacion(entity.getFechaDeCreacion());
+    dto.setCalificacion(entity.getCalificacion());
+    dto.setGeneroId(entity.getGeneroId());
+    if (loadPersonajes) {
+      List<PersonajeDTO> personajeDTOS = this.personajeMapper.personajeEntitySet2DTOList(entity.getPersonajes(), false);
+      dto.setPersonajes(personajeDTOS);
+    }
+    return dto;
+  }
+
+  public List<PeliculaDTO> peliculaEntityList2DTOList(Set<PeliculaEntity> entities, boolean loadPersonajes) {
+    List<PeliculaDTO> dtos = new ArrayList<>();
+    entities.forEach(entity -> dtos.add(this.peliculaEntity2DTO(entity, loadPersonajes)));
+    return dtos;
+  }
+}

--- a/src/main/java/com/alkemy/disney/disney/mapper/PersonajeMapper.java
+++ b/src/main/java/com/alkemy/disney/disney/mapper/PersonajeMapper.java
@@ -1,0 +1,53 @@
+package com.alkemy.disney.disney.mapper;
+
+import com.alkemy.disney.disney.dto.PeliculaDTO;
+import com.alkemy.disney.disney.dto.PersonajeDTO;
+import com.alkemy.disney.disney.entity.PersonajeEntity;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+
+@Component
+public class PersonajeMapper {
+
+  @Autowired
+  private PeliculaMapper peliculaMapper;
+
+  public PersonajeEntity personajeDTO2Entity(PersonajeDTO dto) {
+    PersonajeEntity entity = new PersonajeEntity();
+    entity.setImagen(dto.getImagen());
+    entity.setNombre(dto.getNombre());
+    entity.setEdad(dto.getEdad());
+    entity.setPeso(dto.getPeso());
+    entity.setHistoria(dto.getHistoria());
+    return entity;
+  }
+
+  public PersonajeDTO personajeEntity2DTO(PersonajeEntity entity, boolean loadPeliculas) {
+    PersonajeDTO dto = new PersonajeDTO();
+    dto.setId(entity.getId());
+    dto.setImagen(entity.getImagen());
+    dto.setNombre(entity.getNombre());
+    dto.setEdad(entity.getEdad());
+    dto.setPeso(entity.getPeso());
+    dto.setHistoria(entity.getHistoria());
+    if (loadPeliculas) {
+      List<PeliculaDTO> peliculaDTOS = this.peliculaMapper.peliculaEntityList2DTOList(entity.getPeliculas(), false);
+      dto.setPeliculas(peliculaDTOS);
+    }
+    return dto;
+  }
+
+  public Set<PersonajeEntity> personajeDTOList2Entity(List<PersonajeDTO> dtos) {
+    Set<PersonajeEntity> entities = new HashSet<>();
+    dtos.forEach(dto -> entities.add(this.personajeDTO2Entity(dto)));
+    return entities;
+  }
+
+  public List<PersonajeDTO> personajeEntitySet2DTOList(Collection<PersonajeEntity> entities, boolean loadPeliculas) {
+    List<PersonajeDTO> dtos = new ArrayList<>();
+    entities.forEach(entity -> dtos.add(this.personajeEntity2DTO(entity, loadPeliculas)));
+    return dtos;
+  }
+}

--- a/src/main/java/com/alkemy/disney/disney/mapper/PersonajeMapper.java
+++ b/src/main/java/com/alkemy/disney/disney/mapper/PersonajeMapper.java
@@ -1,6 +1,7 @@
 package com.alkemy.disney.disney.mapper;
 
 import com.alkemy.disney.disney.dto.PeliculaDTO;
+import com.alkemy.disney.disney.dto.PersonajeBasicDTO;
 import com.alkemy.disney.disney.dto.PersonajeDTO;
 import com.alkemy.disney.disney.entity.PersonajeEntity;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -48,6 +49,18 @@ public class PersonajeMapper {
   public List<PersonajeDTO> personajeEntitySet2DTOList(Collection<PersonajeEntity> entities, boolean loadPeliculas) {
     List<PersonajeDTO> dtos = new ArrayList<>();
     entities.forEach(entity -> dtos.add(this.personajeEntity2DTO(entity, loadPeliculas)));
+    return dtos;
+  }
+
+  public List<PersonajeBasicDTO> personajeEntityList2BasicDTOList(Collection<PersonajeEntity> entities) {
+    List<PersonajeBasicDTO> dtos = new ArrayList<>();
+    PersonajeBasicDTO basicDTO;
+    for (PersonajeEntity entity : entities) {
+      basicDTO = new PersonajeBasicDTO();
+      basicDTO.setImagen(entity.getImagen());
+      basicDTO.setNombre(entity.getNombre());
+      dtos.add(basicDTO);
+    }
     return dtos;
   }
 }

--- a/src/main/java/com/alkemy/disney/disney/mapper/PersonajeMapper.java
+++ b/src/main/java/com/alkemy/disney/disney/mapper/PersonajeMapper.java
@@ -63,4 +63,12 @@ public class PersonajeMapper {
     }
     return dtos;
   }
+
+  public void personajeEntityRefreshValues(PersonajeEntity entity, PersonajeDTO personajeDTO) {
+    entity.setHistoria(personajeDTO.getHistoria());
+    entity.setNombre(personajeDTO.getNombre());
+    entity.setImagen(personajeDTO.getImagen());
+    entity.setPeso(personajeDTO.getPeso());
+    entity.setEdad(personajeDTO.getEdad());
+  }
 }

--- a/src/main/java/com/alkemy/disney/disney/repository/GeneroRepository.java
+++ b/src/main/java/com/alkemy/disney/disney/repository/GeneroRepository.java
@@ -1,0 +1,7 @@
+package com.alkemy.disney.disney.repository;
+
+import com.alkemy.disney.disney.entity.GeneroEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GeneroRepository extends JpaRepository<GeneroEntity, Long> {
+}

--- a/src/main/java/com/alkemy/disney/disney/repository/PeliculaRepository.java
+++ b/src/main/java/com/alkemy/disney/disney/repository/PeliculaRepository.java
@@ -1,0 +1,9 @@
+package com.alkemy.disney.disney.repository;
+
+import com.alkemy.disney.disney.entity.PeliculaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PeliculaRepository extends JpaRepository<PeliculaEntity, Long> {
+}

--- a/src/main/java/com/alkemy/disney/disney/repository/PeliculaRepository.java
+++ b/src/main/java/com/alkemy/disney/disney/repository/PeliculaRepository.java
@@ -2,8 +2,9 @@ package com.alkemy.disney.disney.repository;
 
 import com.alkemy.disney.disney.entity.PeliculaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface PeliculaRepository extends JpaRepository<PeliculaEntity, Long> {
+public interface PeliculaRepository extends JpaRepository<PeliculaEntity, Long>, JpaSpecificationExecutor<PeliculaEntity> {
 }

--- a/src/main/java/com/alkemy/disney/disney/repository/PersonajeRepository.java
+++ b/src/main/java/com/alkemy/disney/disney/repository/PersonajeRepository.java
@@ -1,0 +1,7 @@
+package com.alkemy.disney.disney.repository;
+
+import com.alkemy.disney.disney.entity.PersonajeEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PersonajeRepository extends JpaRepository<PersonajeEntity, Long> {
+}

--- a/src/main/java/com/alkemy/disney/disney/repository/PersonajeRepository.java
+++ b/src/main/java/com/alkemy/disney/disney/repository/PersonajeRepository.java
@@ -2,6 +2,7 @@ package com.alkemy.disney.disney.repository;
 
 import com.alkemy.disney.disney.entity.PersonajeEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
-public interface PersonajeRepository extends JpaRepository<PersonajeEntity, Long> {
+public interface PersonajeRepository extends JpaRepository<PersonajeEntity, Long>, JpaSpecificationExecutor<PersonajeEntity> {
 }

--- a/src/main/java/com/alkemy/disney/disney/repository/specifications/PeliculaSpecification.java
+++ b/src/main/java/com/alkemy/disney/disney/repository/specifications/PeliculaSpecification.java
@@ -1,0 +1,33 @@
+package com.alkemy.disney.disney.repository.specifications;
+
+import com.alkemy.disney.disney.dto.PeliculaFilterDTO;
+import com.alkemy.disney.disney.entity.PeliculaEntity;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import javax.persistence.criteria.Predicate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class PeliculaSpecification {
+  public static Specification<PeliculaEntity> getByFilters(PeliculaFilterDTO filterDTO) {
+    return (root, criteriaQuery, criteriaBuilder) -> {
+      List<Predicate> predicates = new ArrayList<>();
+
+      if (StringUtils.hasLength(filterDTO.getName())) {
+        predicates.add(
+            criteriaBuilder.like(
+                criteriaBuilder.lower(root.get("titulo")),
+                "%" + filterDTO.getName().toLowerCase() + "%"
+            )
+        );
+      }
+
+      criteriaQuery.distinct(true);
+
+      return criteriaBuilder.and(predicates.toArray(new Predicate[0]));
+    };
+  }
+}

--- a/src/main/java/com/alkemy/disney/disney/repository/specifications/PeliculaSpecification.java
+++ b/src/main/java/com/alkemy/disney/disney/repository/specifications/PeliculaSpecification.java
@@ -33,6 +33,13 @@ public class PeliculaSpecification {
 
       criteriaQuery.distinct(true);
 
+      String orderByField = "fechaDeCreacion";
+      criteriaQuery.orderBy(
+          filterDTO.isAsc() ?
+              criteriaBuilder.asc(root.get(orderByField)) :
+              criteriaBuilder.desc(root.get(orderByField))
+      );
+
       return criteriaBuilder.and(predicates.toArray(new Predicate[0]));
     };
   }

--- a/src/main/java/com/alkemy/disney/disney/repository/specifications/PeliculaSpecification.java
+++ b/src/main/java/com/alkemy/disney/disney/repository/specifications/PeliculaSpecification.java
@@ -25,6 +25,12 @@ public class PeliculaSpecification {
         );
       }
 
+      if (filterDTO.getIdGenre() != null) {
+        predicates.add(
+            criteriaBuilder.equal(root.<Long>get("genero"), filterDTO.getIdGenre())
+        );
+      }
+
       criteriaQuery.distinct(true);
 
       return criteriaBuilder.and(predicates.toArray(new Predicate[0]));

--- a/src/main/java/com/alkemy/disney/disney/repository/specifications/PersonajeSpecification.java
+++ b/src/main/java/com/alkemy/disney/disney/repository/specifications/PersonajeSpecification.java
@@ -33,6 +33,8 @@ public class PersonajeSpecification {
         );
       }
 
+      criteriaQuery.distinct(true);
+
       return criteriaBuilder.and(predicates.toArray(new Predicate[0]));
     };
   }

--- a/src/main/java/com/alkemy/disney/disney/repository/specifications/PersonajeSpecification.java
+++ b/src/main/java/com/alkemy/disney/disney/repository/specifications/PersonajeSpecification.java
@@ -6,7 +6,6 @@ import com.alkemy.disney.disney.entity.PersonajeEntity;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
-import org.springframework.util.NumberUtils;
 import org.springframework.util.StringUtils;
 
 import javax.persistence.criteria.Expression;

--- a/src/main/java/com/alkemy/disney/disney/repository/specifications/PersonajeSpecification.java
+++ b/src/main/java/com/alkemy/disney/disney/repository/specifications/PersonajeSpecification.java
@@ -1,0 +1,32 @@
+package com.alkemy.disney.disney.repository.specifications;
+
+import com.alkemy.disney.disney.dto.PersonajeFilterDTO;
+import com.alkemy.disney.disney.entity.PersonajeEntity;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import javax.persistence.criteria.Predicate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class PersonajeSpecification {
+  public static Specification<PersonajeEntity> getByFilters(PersonajeFilterDTO filterDTO) {
+
+    return (root, criteriaQuery, criteriaBuilder) -> {
+      List<Predicate> predicates = new ArrayList<>();
+
+      if (StringUtils.hasLength(filterDTO.getName())) {
+        predicates.add(
+            criteriaBuilder.like(
+                criteriaBuilder.lower(root.get("nombre")),
+                "%" + filterDTO.getName().toLowerCase() + "%"
+            )
+        );
+      }
+
+      return criteriaBuilder.and(predicates.toArray(new Predicate[0]));
+    };
+  }
+}

--- a/src/main/java/com/alkemy/disney/disney/repository/specifications/PersonajeSpecification.java
+++ b/src/main/java/com/alkemy/disney/disney/repository/specifications/PersonajeSpecification.java
@@ -1,12 +1,17 @@
 package com.alkemy.disney.disney.repository.specifications;
 
 import com.alkemy.disney.disney.dto.PersonajeFilterDTO;
+import com.alkemy.disney.disney.entity.PeliculaEntity;
 import com.alkemy.disney.disney.entity.PersonajeEntity;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
 import org.springframework.util.NumberUtils;
 import org.springframework.util.StringUtils;
 
+import javax.persistence.criteria.Expression;
+import javax.persistence.criteria.Join;
+import javax.persistence.criteria.JoinType;
 import javax.persistence.criteria.Predicate;
 import java.util.ArrayList;
 import java.util.List;
@@ -31,6 +36,12 @@ public class PersonajeSpecification {
         predicates.add(
             criteriaBuilder.equal(root.<Integer>get("edad"), filterDTO.getEdad())
         );
+      }
+
+      if (!CollectionUtils.isEmpty(filterDTO.getIdMovies())) {
+        Join<PeliculaEntity, PersonajeEntity> join = root.join("peliculas", JoinType.INNER);
+        Expression<String> moviesId = join.get("id");
+        predicates.add(moviesId.in(filterDTO.getIdMovies()));
       }
 
       criteriaQuery.distinct(true);

--- a/src/main/java/com/alkemy/disney/disney/repository/specifications/PersonajeSpecification.java
+++ b/src/main/java/com/alkemy/disney/disney/repository/specifications/PersonajeSpecification.java
@@ -4,6 +4,7 @@ import com.alkemy.disney.disney.dto.PersonajeFilterDTO;
 import com.alkemy.disney.disney.entity.PersonajeEntity;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Component;
+import org.springframework.util.NumberUtils;
 import org.springframework.util.StringUtils;
 
 import javax.persistence.criteria.Predicate;
@@ -23,6 +24,12 @@ public class PersonajeSpecification {
                 criteriaBuilder.lower(root.get("nombre")),
                 "%" + filterDTO.getName().toLowerCase() + "%"
             )
+        );
+      }
+
+      if (filterDTO.getEdad() != null) {
+        predicates.add(
+            criteriaBuilder.equal(root.<Integer>get("edad"), filterDTO.getEdad())
         );
       }
 

--- a/src/main/java/com/alkemy/disney/disney/service/GeneroService.java
+++ b/src/main/java/com/alkemy/disney/disney/service/GeneroService.java
@@ -1,0 +1,7 @@
+package com.alkemy.disney.disney.service;
+
+import com.alkemy.disney.disney.dto.GeneroDTO;
+
+public interface GeneroService {
+  GeneroDTO save(GeneroDTO dto);
+}

--- a/src/main/java/com/alkemy/disney/disney/service/PeliculaService.java
+++ b/src/main/java/com/alkemy/disney/disney/service/PeliculaService.java
@@ -2,6 +2,7 @@ package com.alkemy.disney.disney.service;
 
 import com.alkemy.disney.disney.dto.PeliculaBasicDTO;
 import com.alkemy.disney.disney.dto.PeliculaDTO;
+import com.alkemy.disney.disney.entity.PeliculaEntity;
 
 import java.util.List;
 
@@ -13,4 +14,6 @@ public interface PeliculaService {
   PeliculaDTO getDetailsById(Long id);
 
   void delete(Long id);
+
+  PeliculaEntity getEntityById(Long id);
 }

--- a/src/main/java/com/alkemy/disney/disney/service/PeliculaService.java
+++ b/src/main/java/com/alkemy/disney/disney/service/PeliculaService.java
@@ -8,7 +8,7 @@ import java.util.List;
 public interface PeliculaService {
   PeliculaDTO save(PeliculaDTO dto);
 
-  List<PeliculaBasicDTO> getAll(String name, Long idGenre);
+  List<PeliculaBasicDTO> getAll(String name, Long idGenre, String order);
 
   PeliculaDTO getDetailsById(Long id);
 

--- a/src/main/java/com/alkemy/disney/disney/service/PeliculaService.java
+++ b/src/main/java/com/alkemy/disney/disney/service/PeliculaService.java
@@ -8,7 +8,7 @@ import java.util.List;
 public interface PeliculaService {
   PeliculaDTO save(PeliculaDTO dto);
 
-  List<PeliculaBasicDTO> getAll();
+  List<PeliculaBasicDTO> getAll(String name);
 
   PeliculaDTO getDetailsById(Long id);
 

--- a/src/main/java/com/alkemy/disney/disney/service/PeliculaService.java
+++ b/src/main/java/com/alkemy/disney/disney/service/PeliculaService.java
@@ -11,4 +11,6 @@ public interface PeliculaService {
   List<PeliculaBasicDTO> getAll();
 
   PeliculaDTO getDetailsById(Long id);
+
+  void delete(Long id);
 }

--- a/src/main/java/com/alkemy/disney/disney/service/PeliculaService.java
+++ b/src/main/java/com/alkemy/disney/disney/service/PeliculaService.java
@@ -1,0 +1,7 @@
+package com.alkemy.disney.disney.service;
+
+import com.alkemy.disney.disney.dto.PeliculaDTO;
+
+public interface PeliculaService {
+  PeliculaDTO save(PeliculaDTO dto);
+}

--- a/src/main/java/com/alkemy/disney/disney/service/PeliculaService.java
+++ b/src/main/java/com/alkemy/disney/disney/service/PeliculaService.java
@@ -18,4 +18,6 @@ public interface PeliculaService {
   void addPersonaje(Long id, Long idPersonaje);
 
   void removePersonaje(Long id, Long idPersonaje);
+
+  PeliculaDTO update(Long id, PeliculaDTO pelicula);
 }

--- a/src/main/java/com/alkemy/disney/disney/service/PeliculaService.java
+++ b/src/main/java/com/alkemy/disney/disney/service/PeliculaService.java
@@ -15,5 +15,5 @@ public interface PeliculaService {
 
   void delete(Long id);
 
-  PeliculaEntity getEntityById(Long id);
+  void addPersonaje(Long id, Long idPersonaje);
 }

--- a/src/main/java/com/alkemy/disney/disney/service/PeliculaService.java
+++ b/src/main/java/com/alkemy/disney/disney/service/PeliculaService.java
@@ -8,7 +8,7 @@ import java.util.List;
 public interface PeliculaService {
   PeliculaDTO save(PeliculaDTO dto);
 
-  List<PeliculaBasicDTO> getAll(String name);
+  List<PeliculaBasicDTO> getAll(String name, Long idGenre);
 
   PeliculaDTO getDetailsById(Long id);
 

--- a/src/main/java/com/alkemy/disney/disney/service/PeliculaService.java
+++ b/src/main/java/com/alkemy/disney/disney/service/PeliculaService.java
@@ -9,4 +9,6 @@ public interface PeliculaService {
   PeliculaDTO save(PeliculaDTO dto);
 
   List<PeliculaBasicDTO> getAll();
+
+  PeliculaDTO getDetailsById(Long id);
 }

--- a/src/main/java/com/alkemy/disney/disney/service/PeliculaService.java
+++ b/src/main/java/com/alkemy/disney/disney/service/PeliculaService.java
@@ -1,7 +1,12 @@
 package com.alkemy.disney.disney.service;
 
+import com.alkemy.disney.disney.dto.PeliculaBasicDTO;
 import com.alkemy.disney.disney.dto.PeliculaDTO;
+
+import java.util.List;
 
 public interface PeliculaService {
   PeliculaDTO save(PeliculaDTO dto);
+
+  List<PeliculaBasicDTO> getAll();
 }

--- a/src/main/java/com/alkemy/disney/disney/service/PeliculaService.java
+++ b/src/main/java/com/alkemy/disney/disney/service/PeliculaService.java
@@ -16,4 +16,6 @@ public interface PeliculaService {
   void delete(Long id);
 
   void addPersonaje(Long id, Long idPersonaje);
+
+  void removePersonaje(Long id, Long idPersonaje);
 }

--- a/src/main/java/com/alkemy/disney/disney/service/PeliculaService.java
+++ b/src/main/java/com/alkemy/disney/disney/service/PeliculaService.java
@@ -2,7 +2,6 @@ package com.alkemy.disney.disney.service;
 
 import com.alkemy.disney.disney.dto.PeliculaBasicDTO;
 import com.alkemy.disney.disney.dto.PeliculaDTO;
-import com.alkemy.disney.disney.entity.PeliculaEntity;
 
 import java.util.List;
 

--- a/src/main/java/com/alkemy/disney/disney/service/PersonajeService.java
+++ b/src/main/java/com/alkemy/disney/disney/service/PersonajeService.java
@@ -9,7 +9,7 @@ import java.util.List;
 public interface PersonajeService {
   PersonajeDTO save(PersonajeDTO dto);
 
-  List<PersonajeBasicDTO> getAll(String name, Integer age);
+  List<PersonajeBasicDTO> getAll(String name, Integer age, List<Long> idMovies);
 
   PersonajeDTO getDetailsById(Long id);
 

--- a/src/main/java/com/alkemy/disney/disney/service/PersonajeService.java
+++ b/src/main/java/com/alkemy/disney/disney/service/PersonajeService.java
@@ -9,4 +9,6 @@ public interface PersonajeService {
   PersonajeDTO save(PersonajeDTO dto);
 
   List<PersonajeBasicDTO> getAll();
+
+  PersonajeDTO getDetailsById(Long id);
 }

--- a/src/main/java/com/alkemy/disney/disney/service/PersonajeService.java
+++ b/src/main/java/com/alkemy/disney/disney/service/PersonajeService.java
@@ -9,7 +9,7 @@ import java.util.List;
 public interface PersonajeService {
   PersonajeDTO save(PersonajeDTO dto);
 
-  List<PersonajeBasicDTO> getAll();
+  List<PersonajeBasicDTO> getAll(String name);
 
   PersonajeDTO getDetailsById(Long id);
 

--- a/src/main/java/com/alkemy/disney/disney/service/PersonajeService.java
+++ b/src/main/java/com/alkemy/disney/disney/service/PersonajeService.java
@@ -9,7 +9,7 @@ import java.util.List;
 public interface PersonajeService {
   PersonajeDTO save(PersonajeDTO dto);
 
-  List<PersonajeBasicDTO> getAll(String name);
+  List<PersonajeBasicDTO> getAll(String name, Integer age);
 
   PersonajeDTO getDetailsById(Long id);
 

--- a/src/main/java/com/alkemy/disney/disney/service/PersonajeService.java
+++ b/src/main/java/com/alkemy/disney/disney/service/PersonajeService.java
@@ -2,6 +2,7 @@ package com.alkemy.disney.disney.service;
 
 import com.alkemy.disney.disney.dto.PersonajeBasicDTO;
 import com.alkemy.disney.disney.dto.PersonajeDTO;
+import com.alkemy.disney.disney.entity.PersonajeEntity;
 
 import java.util.List;
 
@@ -16,5 +17,5 @@ public interface PersonajeService {
 
   void delete(Long id);
 
-  void addPelicula(Long id, Long idPelicula);
+  PersonajeEntity getById(Long idPersonaje);
 }

--- a/src/main/java/com/alkemy/disney/disney/service/PersonajeService.java
+++ b/src/main/java/com/alkemy/disney/disney/service/PersonajeService.java
@@ -15,4 +15,6 @@ public interface PersonajeService {
   PersonajeDTO update(Long id, PersonajeDTO personaje);
 
   void delete(Long id);
+
+  void addPelicula(Long id, Long idPelicula);
 }

--- a/src/main/java/com/alkemy/disney/disney/service/PersonajeService.java
+++ b/src/main/java/com/alkemy/disney/disney/service/PersonajeService.java
@@ -1,7 +1,12 @@
 package com.alkemy.disney.disney.service;
 
+import com.alkemy.disney.disney.dto.PersonajeBasicDTO;
 import com.alkemy.disney.disney.dto.PersonajeDTO;
+
+import java.util.List;
 
 public interface PersonajeService {
   PersonajeDTO save(PersonajeDTO dto);
+
+  List<PersonajeBasicDTO> getAll();
 }

--- a/src/main/java/com/alkemy/disney/disney/service/PersonajeService.java
+++ b/src/main/java/com/alkemy/disney/disney/service/PersonajeService.java
@@ -13,4 +13,6 @@ public interface PersonajeService {
   PersonajeDTO getDetailsById(Long id);
 
   PersonajeDTO update(Long id, PersonajeDTO personaje);
+
+  void delete(Long id);
 }

--- a/src/main/java/com/alkemy/disney/disney/service/PersonajeService.java
+++ b/src/main/java/com/alkemy/disney/disney/service/PersonajeService.java
@@ -1,0 +1,7 @@
+package com.alkemy.disney.disney.service;
+
+import com.alkemy.disney.disney.dto.PersonajeDTO;
+
+public interface PersonajeService {
+  PersonajeDTO save(PersonajeDTO dto);
+}

--- a/src/main/java/com/alkemy/disney/disney/service/PersonajeService.java
+++ b/src/main/java/com/alkemy/disney/disney/service/PersonajeService.java
@@ -11,4 +11,6 @@ public interface PersonajeService {
   List<PersonajeBasicDTO> getAll();
 
   PersonajeDTO getDetailsById(Long id);
+
+  PersonajeDTO update(Long id, PersonajeDTO personaje);
 }

--- a/src/main/java/com/alkemy/disney/disney/service/impl/GeneroServiceImpl.java
+++ b/src/main/java/com/alkemy/disney/disney/service/impl/GeneroServiceImpl.java
@@ -1,0 +1,25 @@
+package com.alkemy.disney.disney.service.impl;
+
+import com.alkemy.disney.disney.dto.GeneroDTO;
+import com.alkemy.disney.disney.entity.GeneroEntity;
+import com.alkemy.disney.disney.mapper.GeneroMapper;
+import com.alkemy.disney.disney.repository.GeneroRepository;
+import com.alkemy.disney.disney.service.GeneroService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class GeneroServiceImpl implements GeneroService {
+
+  @Autowired
+  private GeneroMapper generoMapper;
+
+  @Autowired
+  private GeneroRepository generoRepository;
+
+  public GeneroDTO save(GeneroDTO dto) {
+    GeneroEntity generoEntity = generoMapper.generoDTO2Entity(dto);
+    GeneroEntity entitySave = this.generoRepository.save(generoEntity);
+    return this.generoMapper.generoEntity2DTO(entitySave);
+  }
+}

--- a/src/main/java/com/alkemy/disney/disney/service/impl/GeneroServiceImpl.java
+++ b/src/main/java/com/alkemy/disney/disney/service/impl/GeneroServiceImpl.java
@@ -11,8 +11,8 @@ import org.springframework.stereotype.Service;
 @Service
 public class GeneroServiceImpl implements GeneroService {
 
-  private GeneroMapper generoMapper;
-  private GeneroRepository generoRepository;
+  private final GeneroMapper generoMapper;
+  private final GeneroRepository generoRepository;
 
   @Autowired
   public GeneroServiceImpl(GeneroMapper generoMapper, GeneroRepository generoRepository) {

--- a/src/main/java/com/alkemy/disney/disney/service/impl/GeneroServiceImpl.java
+++ b/src/main/java/com/alkemy/disney/disney/service/impl/GeneroServiceImpl.java
@@ -11,11 +11,14 @@ import org.springframework.stereotype.Service;
 @Service
 public class GeneroServiceImpl implements GeneroService {
 
-  @Autowired
   private GeneroMapper generoMapper;
+  private GeneroRepository generoRepository;
 
   @Autowired
-  private GeneroRepository generoRepository;
+  public GeneroServiceImpl(GeneroMapper generoMapper, GeneroRepository generoRepository) {
+    this.generoMapper = generoMapper;
+    this.generoRepository = generoRepository;
+  }
 
   public GeneroDTO save(GeneroDTO dto) {
     GeneroEntity generoEntity = generoMapper.generoDTO2Entity(dto);

--- a/src/main/java/com/alkemy/disney/disney/service/impl/PeliculaServiceImpl.java
+++ b/src/main/java/com/alkemy/disney/disney/service/impl/PeliculaServiceImpl.java
@@ -39,8 +39,8 @@ public class PeliculaServiceImpl implements PeliculaService {
   }
 
   @Override
-  public List<PeliculaBasicDTO> getAll(String name) {
-    PeliculaFilterDTO peliculaFilterDTO = new PeliculaFilterDTO(name);
+  public List<PeliculaBasicDTO> getAll(String name, Long idGenre) {
+    PeliculaFilterDTO peliculaFilterDTO = new PeliculaFilterDTO(name, idGenre);
     Specification<PeliculaEntity> spec = PeliculaSpecification.getByFilters(peliculaFilterDTO);
     List<PeliculaEntity> all = peliculaRepository.findAll(spec);
     return peliculaMapper.pelicualEntityList2BasicDTOList(all);

--- a/src/main/java/com/alkemy/disney/disney/service/impl/PeliculaServiceImpl.java
+++ b/src/main/java/com/alkemy/disney/disney/service/impl/PeliculaServiceImpl.java
@@ -59,4 +59,12 @@ public class PeliculaServiceImpl implements PeliculaService {
     entity.addPersonaje(personajeEntity);
     peliculaRepository.save(entity);
   }
+
+  @Override
+  public void removePersonaje(Long id, Long idPersonaje) {
+    PeliculaEntity entity = peliculaRepository.getById(id);
+    PersonajeEntity personajeEntity = personajeService.getById(idPersonaje);
+    entity.removePersonaje(personajeEntity);
+    peliculaRepository.save(entity);
+  }
 }

--- a/src/main/java/com/alkemy/disney/disney/service/impl/PeliculaServiceImpl.java
+++ b/src/main/java/com/alkemy/disney/disney/service/impl/PeliculaServiceImpl.java
@@ -42,4 +42,9 @@ public class PeliculaServiceImpl implements PeliculaService {
         .map(e -> this.peliculaMapper.peliculaEntity2DTO(e, true))
         .orElseThrow(() -> new ParamNotFound("Id de personaje no valido"));
   }
+
+  @Override
+  public void delete(Long id) {
+    this.peliculaRepository.deleteById(id);
+  }
 }

--- a/src/main/java/com/alkemy/disney/disney/service/impl/PeliculaServiceImpl.java
+++ b/src/main/java/com/alkemy/disney/disney/service/impl/PeliculaServiceImpl.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 public class PeliculaServiceImpl implements PeliculaService {
@@ -66,5 +67,16 @@ public class PeliculaServiceImpl implements PeliculaService {
     PersonajeEntity personajeEntity = personajeService.getById(idPersonaje);
     entity.removePersonaje(personajeEntity);
     peliculaRepository.save(entity);
+  }
+
+  @Override
+  public PeliculaDTO update(Long id, PeliculaDTO peliculaDTO) {
+    Optional<PeliculaEntity> entity = peliculaRepository.findById(id);
+    if (entity.isEmpty()) {
+      throw new ParamNotFound("Id de presonaje no valido");
+    }
+    this.peliculaMapper.peliculaEntityRefreshValues(entity.get(), peliculaDTO);
+    PeliculaEntity peliculaSaved = this.peliculaRepository.save(entity.get());
+    return peliculaMapper.peliculaEntity2DTO(peliculaSaved, false);
   }
 }

--- a/src/main/java/com/alkemy/disney/disney/service/impl/PeliculaServiceImpl.java
+++ b/src/main/java/com/alkemy/disney/disney/service/impl/PeliculaServiceImpl.java
@@ -41,6 +41,6 @@ public class PeliculaServiceImpl implements PeliculaService {
   public PeliculaDTO getDetailsById(Long id) {
     return this.peliculaRepository.findById(id)
         .map(e -> this.peliculaMapper.peliculaEntity2DTO(e, true))
-        .orElseThrow(() -> new ParamNotFound("No se encotro el personaje"));
+        .orElseThrow(() -> new ParamNotFound("Id de personaje no valido"));
   }
 }

--- a/src/main/java/com/alkemy/disney/disney/service/impl/PeliculaServiceImpl.java
+++ b/src/main/java/com/alkemy/disney/disney/service/impl/PeliculaServiceImpl.java
@@ -3,10 +3,12 @@ package com.alkemy.disney.disney.service.impl;
 import com.alkemy.disney.disney.dto.PeliculaBasicDTO;
 import com.alkemy.disney.disney.dto.PeliculaDTO;
 import com.alkemy.disney.disney.entity.PeliculaEntity;
+import com.alkemy.disney.disney.entity.PersonajeEntity;
 import com.alkemy.disney.disney.exception.ParamNotFound;
 import com.alkemy.disney.disney.mapper.PeliculaMapper;
 import com.alkemy.disney.disney.repository.PeliculaRepository;
 import com.alkemy.disney.disney.service.PeliculaService;
+import com.alkemy.disney.disney.service.PersonajeService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -16,12 +18,14 @@ import java.util.List;
 public class PeliculaServiceImpl implements PeliculaService {
 
   private final PeliculaRepository peliculaRepository;
+  private final PersonajeService personajeService;
   private final PeliculaMapper peliculaMapper;
 
   @Autowired
-  public PeliculaServiceImpl(PeliculaMapper peliculaMapper, PeliculaRepository peliculaRepository) {
+  public PeliculaServiceImpl(PeliculaMapper peliculaMapper, PeliculaRepository peliculaRepository, PersonajeService personajeService) {
     this.peliculaMapper = peliculaMapper;
     this.peliculaRepository = peliculaRepository;
+    this.personajeService = personajeService;
   }
 
   public PeliculaDTO save(PeliculaDTO dto) {
@@ -49,7 +53,10 @@ public class PeliculaServiceImpl implements PeliculaService {
   }
 
   @Override
-  public PeliculaEntity getEntityById(Long id) {
-    return this.peliculaRepository.getById(id);
+  public void addPersonaje(Long id, Long idPersonaje) {
+    PeliculaEntity entity = peliculaRepository.getById(id);
+    PersonajeEntity personajeEntity = personajeService.getById(idPersonaje);
+    entity.addPersonaje(personajeEntity);
+    peliculaRepository.save(entity);
   }
 }

--- a/src/main/java/com/alkemy/disney/disney/service/impl/PeliculaServiceImpl.java
+++ b/src/main/java/com/alkemy/disney/disney/service/impl/PeliculaServiceImpl.java
@@ -2,14 +2,17 @@ package com.alkemy.disney.disney.service.impl;
 
 import com.alkemy.disney.disney.dto.PeliculaBasicDTO;
 import com.alkemy.disney.disney.dto.PeliculaDTO;
+import com.alkemy.disney.disney.dto.PeliculaFilterDTO;
 import com.alkemy.disney.disney.entity.PeliculaEntity;
 import com.alkemy.disney.disney.entity.PersonajeEntity;
 import com.alkemy.disney.disney.exception.ParamNotFound;
 import com.alkemy.disney.disney.mapper.PeliculaMapper;
 import com.alkemy.disney.disney.repository.PeliculaRepository;
+import com.alkemy.disney.disney.repository.specifications.PeliculaSpecification;
 import com.alkemy.disney.disney.service.PeliculaService;
 import com.alkemy.disney.disney.service.PersonajeService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -36,8 +39,10 @@ public class PeliculaServiceImpl implements PeliculaService {
   }
 
   @Override
-  public List<PeliculaBasicDTO> getAll() {
-    List<PeliculaEntity> all = peliculaRepository.findAll();
+  public List<PeliculaBasicDTO> getAll(String name) {
+    PeliculaFilterDTO peliculaFilterDTO = new PeliculaFilterDTO(name);
+    Specification<PeliculaEntity> spec = PeliculaSpecification.getByFilters(peliculaFilterDTO);
+    List<PeliculaEntity> all = peliculaRepository.findAll(spec);
     return peliculaMapper.pelicualEntityList2BasicDTOList(all);
   }
 

--- a/src/main/java/com/alkemy/disney/disney/service/impl/PeliculaServiceImpl.java
+++ b/src/main/java/com/alkemy/disney/disney/service/impl/PeliculaServiceImpl.java
@@ -7,7 +7,6 @@ import com.alkemy.disney.disney.exception.ParamNotFound;
 import com.alkemy.disney.disney.mapper.PeliculaMapper;
 import com.alkemy.disney.disney.repository.PeliculaRepository;
 import com.alkemy.disney.disney.service.PeliculaService;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -16,8 +15,8 @@ import java.util.List;
 @Service
 public class PeliculaServiceImpl implements PeliculaService {
 
-  private PeliculaRepository peliculaRepository;
-  private PeliculaMapper peliculaMapper;
+  private final PeliculaRepository peliculaRepository;
+  private final PeliculaMapper peliculaMapper;
 
   @Autowired
   public PeliculaServiceImpl(PeliculaMapper peliculaMapper, PeliculaRepository peliculaRepository) {

--- a/src/main/java/com/alkemy/disney/disney/service/impl/PeliculaServiceImpl.java
+++ b/src/main/java/com/alkemy/disney/disney/service/impl/PeliculaServiceImpl.java
@@ -39,8 +39,8 @@ public class PeliculaServiceImpl implements PeliculaService {
   }
 
   @Override
-  public List<PeliculaBasicDTO> getAll(String name, Long idGenre) {
-    PeliculaFilterDTO peliculaFilterDTO = new PeliculaFilterDTO(name, idGenre);
+  public List<PeliculaBasicDTO> getAll(String name, Long idGenre, String order) {
+    PeliculaFilterDTO peliculaFilterDTO = new PeliculaFilterDTO(name, idGenre, order);
     Specification<PeliculaEntity> spec = PeliculaSpecification.getByFilters(peliculaFilterDTO);
     List<PeliculaEntity> all = peliculaRepository.findAll(spec);
     return peliculaMapper.pelicualEntityList2BasicDTOList(all);

--- a/src/main/java/com/alkemy/disney/disney/service/impl/PeliculaServiceImpl.java
+++ b/src/main/java/com/alkemy/disney/disney/service/impl/PeliculaServiceImpl.java
@@ -47,4 +47,9 @@ public class PeliculaServiceImpl implements PeliculaService {
   public void delete(Long id) {
     this.peliculaRepository.deleteById(id);
   }
+
+  @Override
+  public PeliculaEntity getEntityById(Long id) {
+    return this.peliculaRepository.getById(id);
+  }
 }

--- a/src/main/java/com/alkemy/disney/disney/service/impl/PeliculaServiceImpl.java
+++ b/src/main/java/com/alkemy/disney/disney/service/impl/PeliculaServiceImpl.java
@@ -1,5 +1,6 @@
 package com.alkemy.disney.disney.service.impl;
 
+import com.alkemy.disney.disney.dto.PeliculaBasicDTO;
 import com.alkemy.disney.disney.dto.PeliculaDTO;
 import com.alkemy.disney.disney.entity.PeliculaEntity;
 import com.alkemy.disney.disney.mapper.PeliculaMapper;
@@ -8,6 +9,8 @@ import com.alkemy.disney.disney.service.PeliculaService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 public class PeliculaServiceImpl implements PeliculaService {
@@ -25,5 +28,11 @@ public class PeliculaServiceImpl implements PeliculaService {
     PeliculaEntity peliculaEntity = peliculaMapper.peliculaDTO2Entity(dto);
     PeliculaEntity entitySave = this.peliculaRepository.save(peliculaEntity);
     return this.peliculaMapper.peliculaEntity2DTO(entitySave, true);
+  }
+
+  @Override
+  public List<PeliculaBasicDTO> getAll() {
+    List<PeliculaEntity> all = peliculaRepository.findAll();
+    return peliculaMapper.pelicualEntityList2BasicDTOList(all);
   }
 }

--- a/src/main/java/com/alkemy/disney/disney/service/impl/PeliculaServiceImpl.java
+++ b/src/main/java/com/alkemy/disney/disney/service/impl/PeliculaServiceImpl.java
@@ -40,7 +40,7 @@ public class PeliculaServiceImpl implements PeliculaService {
   public PeliculaDTO getDetailsById(Long id) {
     return this.peliculaRepository.findById(id)
         .map(e -> this.peliculaMapper.peliculaEntity2DTO(e, true))
-        .orElseThrow(() -> new ParamNotFound("Id de personaje no valido"));
+        .orElseThrow(() -> new ParamNotFound("Id de pelicula no valido"));
   }
 
   @Override

--- a/src/main/java/com/alkemy/disney/disney/service/impl/PeliculaServiceImpl.java
+++ b/src/main/java/com/alkemy/disney/disney/service/impl/PeliculaServiceImpl.java
@@ -3,6 +3,7 @@ package com.alkemy.disney.disney.service.impl;
 import com.alkemy.disney.disney.dto.PeliculaBasicDTO;
 import com.alkemy.disney.disney.dto.PeliculaDTO;
 import com.alkemy.disney.disney.entity.PeliculaEntity;
+import com.alkemy.disney.disney.exception.ParamNotFound;
 import com.alkemy.disney.disney.mapper.PeliculaMapper;
 import com.alkemy.disney.disney.repository.PeliculaRepository;
 import com.alkemy.disney.disney.service.PeliculaService;
@@ -34,5 +35,12 @@ public class PeliculaServiceImpl implements PeliculaService {
   public List<PeliculaBasicDTO> getAll() {
     List<PeliculaEntity> all = peliculaRepository.findAll();
     return peliculaMapper.pelicualEntityList2BasicDTOList(all);
+  }
+
+  @Override
+  public PeliculaDTO getDetailsById(Long id) {
+    return this.peliculaRepository.findById(id)
+        .map(e -> this.peliculaMapper.peliculaEntity2DTO(e, true))
+        .orElseThrow(() -> new ParamNotFound("No se encotro el personaje"));
   }
 }

--- a/src/main/java/com/alkemy/disney/disney/service/impl/PeliculaServiceImpl.java
+++ b/src/main/java/com/alkemy/disney/disney/service/impl/PeliculaServiceImpl.java
@@ -1,0 +1,29 @@
+package com.alkemy.disney.disney.service.impl;
+
+import com.alkemy.disney.disney.dto.PeliculaDTO;
+import com.alkemy.disney.disney.entity.PeliculaEntity;
+import com.alkemy.disney.disney.mapper.PeliculaMapper;
+import com.alkemy.disney.disney.repository.PeliculaRepository;
+import com.alkemy.disney.disney.service.PeliculaService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PeliculaServiceImpl implements PeliculaService {
+
+  private PeliculaRepository peliculaRepository;
+  private PeliculaMapper peliculaMapper;
+
+  @Autowired
+  public PeliculaServiceImpl(PeliculaMapper peliculaMapper, PeliculaRepository peliculaRepository) {
+    this.peliculaMapper = peliculaMapper;
+    this.peliculaRepository = peliculaRepository;
+  }
+
+  public PeliculaDTO save(PeliculaDTO dto) {
+    PeliculaEntity peliculaEntity = peliculaMapper.peliculaDTO2Entity(dto);
+    PeliculaEntity entitySave = this.peliculaRepository.save(peliculaEntity);
+    return this.peliculaMapper.peliculaEntity2DTO(entitySave, true);
+  }
+}

--- a/src/main/java/com/alkemy/disney/disney/service/impl/PersonajeServiceImpl.java
+++ b/src/main/java/com/alkemy/disney/disney/service/impl/PersonajeServiceImpl.java
@@ -9,7 +9,6 @@ import com.alkemy.disney.disney.mapper.PersonajeMapper;
 import com.alkemy.disney.disney.repository.PersonajeRepository;
 import com.alkemy.disney.disney.service.PeliculaService;
 import com.alkemy.disney.disney.service.PersonajeService;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -20,13 +19,11 @@ import java.util.Optional;
 public class PersonajeServiceImpl implements PersonajeService {
 
   private final PersonajeRepository personajeRepository;
-  private final PeliculaService peliculaService;
   private final PersonajeMapper personajeMapper;
 
   @Autowired
-  public PersonajeServiceImpl(PersonajeRepository personajeRepository, PeliculaService peliculaService, PersonajeMapper personajeMapper) {
+  public PersonajeServiceImpl(PersonajeRepository personajeRepository, PersonajeMapper personajeMapper) {
     this.personajeRepository = personajeRepository;
-    this.peliculaService = peliculaService;
     this.personajeMapper = personajeMapper;
   }
 
@@ -66,10 +63,7 @@ public class PersonajeServiceImpl implements PersonajeService {
   }
 
   @Override
-  public void addPelicula(Long id, Long idPelicula) {
-    PersonajeEntity entity = this.personajeRepository.getById(id);
-    PeliculaEntity peliculaEntity = this.peliculaService.getEntityById(idPelicula);
-    entity.agregarPelicula(peliculaEntity);
-    this.personajeRepository.save(entity);
+  public PersonajeEntity getById(Long idPersonaje) {
+    return this.personajeRepository.getById(idPersonaje);
   }
 }

--- a/src/main/java/com/alkemy/disney/disney/service/impl/PersonajeServiceImpl.java
+++ b/src/main/java/com/alkemy/disney/disney/service/impl/PersonajeServiceImpl.java
@@ -54,4 +54,9 @@ public class PersonajeServiceImpl implements PersonajeService {
     PersonajeEntity personajeSaved = this.personajeRepository.save(entity.get());
     return personajeMapper.personajeEntity2DTO(personajeSaved, false);
   }
+
+  @Override
+  public void delete(Long id) {
+    this.personajeRepository.deleteById(id);
+  }
 }

--- a/src/main/java/com/alkemy/disney/disney/service/impl/PersonajeServiceImpl.java
+++ b/src/main/java/com/alkemy/disney/disney/service/impl/PersonajeServiceImpl.java
@@ -1,5 +1,6 @@
 package com.alkemy.disney.disney.service.impl;
 
+import com.alkemy.disney.disney.dto.PersonajeBasicDTO;
 import com.alkemy.disney.disney.dto.PersonajeDTO;
 import com.alkemy.disney.disney.entity.PersonajeEntity;
 import com.alkemy.disney.disney.mapper.PersonajeMapper;
@@ -7,6 +8,8 @@ import com.alkemy.disney.disney.repository.PersonajeRepository;
 import com.alkemy.disney.disney.service.PersonajeService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 public class PersonajeServiceImpl implements PersonajeService {
@@ -24,5 +27,11 @@ public class PersonajeServiceImpl implements PersonajeService {
     PersonajeEntity entity = personajeMapper.personajeDTO2Entity(dto);
     PersonajeEntity save = personajeRepository.save(entity);
     return personajeMapper.personajeEntity2DTO(save, false);
+  }
+
+  @Override
+  public List<PersonajeBasicDTO> getAll() {
+    List<PersonajeEntity> entities = this.personajeRepository.findAll();
+    return personajeMapper.personajeEntityList2BasicDTOList(entities);
   }
 }

--- a/src/main/java/com/alkemy/disney/disney/service/impl/PersonajeServiceImpl.java
+++ b/src/main/java/com/alkemy/disney/disney/service/impl/PersonajeServiceImpl.java
@@ -35,8 +35,8 @@ public class PersonajeServiceImpl implements PersonajeService {
   }
 
   @Override
-  public List<PersonajeBasicDTO> getAll(String name) {
-    PersonajeFilterDTO personajeFilterDTO = new PersonajeFilterDTO(name);
+  public List<PersonajeBasicDTO> getAll(String name, Integer age) {
+    PersonajeFilterDTO personajeFilterDTO = new PersonajeFilterDTO(name, age);
     Specification<PersonajeEntity> spec = PersonajeSpecification.getByFilters(personajeFilterDTO);
     List<PersonajeEntity> entities = this.personajeRepository.findAll(spec);
     return personajeMapper.personajeEntityList2BasicDTOList(entities);

--- a/src/main/java/com/alkemy/disney/disney/service/impl/PersonajeServiceImpl.java
+++ b/src/main/java/com/alkemy/disney/disney/service/impl/PersonajeServiceImpl.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 public class PersonajeServiceImpl implements PersonajeService {
@@ -33,5 +34,14 @@ public class PersonajeServiceImpl implements PersonajeService {
   public List<PersonajeBasicDTO> getAll() {
     List<PersonajeEntity> entities = this.personajeRepository.findAll();
     return personajeMapper.personajeEntityList2BasicDTOList(entities);
+  }
+
+  @Override
+  public PersonajeDTO getDetailsById(Long id) {
+    Optional<PersonajeEntity> entity = this.personajeRepository.findById(id);
+    if (entity.isEmpty()) {
+      return null;
+    }
+    return this.personajeMapper.personajeEntity2DTO(entity.get(), true);
   }
 }

--- a/src/main/java/com/alkemy/disney/disney/service/impl/PersonajeServiceImpl.java
+++ b/src/main/java/com/alkemy/disney/disney/service/impl/PersonajeServiceImpl.java
@@ -39,10 +39,9 @@ public class PersonajeServiceImpl implements PersonajeService {
 
   @Override
   public PersonajeDTO getDetailsById(Long id) {
-    // TODO: agregar excepcion posta
     return this.personajeRepository.findById(id)
         .map(e -> this.personajeMapper.personajeEntity2DTO(e, true))
-        .orElseThrow(() -> new RuntimeException("no se encontro"));
+        .orElseThrow(() -> new ParamNotFound("no se encontro"));
   }
 
   @Override

--- a/src/main/java/com/alkemy/disney/disney/service/impl/PersonajeServiceImpl.java
+++ b/src/main/java/com/alkemy/disney/disney/service/impl/PersonajeServiceImpl.java
@@ -2,12 +2,10 @@ package com.alkemy.disney.disney.service.impl;
 
 import com.alkemy.disney.disney.dto.PersonajeBasicDTO;
 import com.alkemy.disney.disney.dto.PersonajeDTO;
-import com.alkemy.disney.disney.entity.PeliculaEntity;
 import com.alkemy.disney.disney.entity.PersonajeEntity;
 import com.alkemy.disney.disney.exception.ParamNotFound;
 import com.alkemy.disney.disney.mapper.PersonajeMapper;
 import com.alkemy.disney.disney.repository.PersonajeRepository;
-import com.alkemy.disney.disney.service.PeliculaService;
 import com.alkemy.disney.disney.service.PersonajeService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/alkemy/disney/disney/service/impl/PersonajeServiceImpl.java
+++ b/src/main/java/com/alkemy/disney/disney/service/impl/PersonajeServiceImpl.java
@@ -2,12 +2,15 @@ package com.alkemy.disney.disney.service.impl;
 
 import com.alkemy.disney.disney.dto.PersonajeBasicDTO;
 import com.alkemy.disney.disney.dto.PersonajeDTO;
+import com.alkemy.disney.disney.dto.PersonajeFilterDTO;
 import com.alkemy.disney.disney.entity.PersonajeEntity;
 import com.alkemy.disney.disney.exception.ParamNotFound;
 import com.alkemy.disney.disney.mapper.PersonajeMapper;
 import com.alkemy.disney.disney.repository.PersonajeRepository;
+import com.alkemy.disney.disney.repository.specifications.PersonajeSpecification;
 import com.alkemy.disney.disney.service.PersonajeService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -32,8 +35,10 @@ public class PersonajeServiceImpl implements PersonajeService {
   }
 
   @Override
-  public List<PersonajeBasicDTO> getAll() {
-    List<PersonajeEntity> entities = this.personajeRepository.findAll();
+  public List<PersonajeBasicDTO> getAll(String name) {
+    PersonajeFilterDTO personajeFilterDTO = new PersonajeFilterDTO(name);
+    Specification<PersonajeEntity> spec = PersonajeSpecification.getByFilters(personajeFilterDTO);
+    List<PersonajeEntity> entities = this.personajeRepository.findAll(spec);
     return personajeMapper.personajeEntityList2BasicDTOList(entities);
   }
 

--- a/src/main/java/com/alkemy/disney/disney/service/impl/PersonajeServiceImpl.java
+++ b/src/main/java/com/alkemy/disney/disney/service/impl/PersonajeServiceImpl.java
@@ -1,0 +1,28 @@
+package com.alkemy.disney.disney.service.impl;
+
+import com.alkemy.disney.disney.dto.PersonajeDTO;
+import com.alkemy.disney.disney.entity.PersonajeEntity;
+import com.alkemy.disney.disney.mapper.PersonajeMapper;
+import com.alkemy.disney.disney.repository.PersonajeRepository;
+import com.alkemy.disney.disney.service.PersonajeService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PersonajeServiceImpl implements PersonajeService {
+
+  private PersonajeRepository personajeRepository;
+  private PersonajeMapper personajeMapper;
+
+  @Autowired
+  public PersonajeServiceImpl(PersonajeRepository personajeRepository, PersonajeMapper personajeMapper) {
+    this.personajeRepository = personajeRepository;
+    this.personajeMapper = personajeMapper;
+  }
+
+  public PersonajeDTO save(PersonajeDTO dto) {
+    PersonajeEntity entity = personajeMapper.personajeDTO2Entity(dto);
+    PersonajeEntity save = personajeRepository.save(entity);
+    return personajeMapper.personajeEntity2DTO(save, false);
+  }
+}

--- a/src/main/java/com/alkemy/disney/disney/service/impl/PersonajeServiceImpl.java
+++ b/src/main/java/com/alkemy/disney/disney/service/impl/PersonajeServiceImpl.java
@@ -3,6 +3,7 @@ package com.alkemy.disney.disney.service.impl;
 import com.alkemy.disney.disney.dto.PersonajeBasicDTO;
 import com.alkemy.disney.disney.dto.PersonajeDTO;
 import com.alkemy.disney.disney.entity.PersonajeEntity;
+import com.alkemy.disney.disney.exception.ParamNotFound;
 import com.alkemy.disney.disney.mapper.PersonajeMapper;
 import com.alkemy.disney.disney.repository.PersonajeRepository;
 import com.alkemy.disney.disney.service.PersonajeService;
@@ -10,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 public class PersonajeServiceImpl implements PersonajeService {
@@ -41,5 +43,16 @@ public class PersonajeServiceImpl implements PersonajeService {
     return this.personajeRepository.findById(id)
         .map(e -> this.personajeMapper.personajeEntity2DTO(e, true))
         .orElseThrow(() -> new RuntimeException("no se encontro"));
+  }
+
+  @Override
+  public PersonajeDTO update(Long id, PersonajeDTO personajeDTO) {
+    Optional<PersonajeEntity> entity = personajeRepository.findById(id);
+    if (entity.isEmpty()) {
+      throw new ParamNotFound("Id de presonaje no valido");
+    }
+    this.personajeMapper.personajeEntityRefreshValues(entity.get(), personajeDTO);
+    PersonajeEntity personajeSaved = this.personajeRepository.save(entity.get());
+    return personajeMapper.personajeEntity2DTO(personajeSaved, false);
   }
 }

--- a/src/main/java/com/alkemy/disney/disney/service/impl/PersonajeServiceImpl.java
+++ b/src/main/java/com/alkemy/disney/disney/service/impl/PersonajeServiceImpl.java
@@ -10,7 +10,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.Optional;
 
 @Service
 public class PersonajeServiceImpl implements PersonajeService {
@@ -38,10 +37,9 @@ public class PersonajeServiceImpl implements PersonajeService {
 
   @Override
   public PersonajeDTO getDetailsById(Long id) {
-    Optional<PersonajeEntity> entity = this.personajeRepository.findById(id);
-    if (entity.isEmpty()) {
-      return null;
-    }
-    return this.personajeMapper.personajeEntity2DTO(entity.get(), true);
+    // TODO: agregar excepcion posta
+    return this.personajeRepository.findById(id)
+        .map(e -> this.personajeMapper.personajeEntity2DTO(e, true))
+        .orElseThrow(() -> new RuntimeException("no se encontro"));
   }
 }

--- a/src/main/java/com/alkemy/disney/disney/service/impl/PersonajeServiceImpl.java
+++ b/src/main/java/com/alkemy/disney/disney/service/impl/PersonajeServiceImpl.java
@@ -2,11 +2,14 @@ package com.alkemy.disney.disney.service.impl;
 
 import com.alkemy.disney.disney.dto.PersonajeBasicDTO;
 import com.alkemy.disney.disney.dto.PersonajeDTO;
+import com.alkemy.disney.disney.entity.PeliculaEntity;
 import com.alkemy.disney.disney.entity.PersonajeEntity;
 import com.alkemy.disney.disney.exception.ParamNotFound;
 import com.alkemy.disney.disney.mapper.PersonajeMapper;
 import com.alkemy.disney.disney.repository.PersonajeRepository;
+import com.alkemy.disney.disney.service.PeliculaService;
 import com.alkemy.disney.disney.service.PersonajeService;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -17,11 +20,13 @@ import java.util.Optional;
 public class PersonajeServiceImpl implements PersonajeService {
 
   private final PersonajeRepository personajeRepository;
+  private final PeliculaService peliculaService;
   private final PersonajeMapper personajeMapper;
 
   @Autowired
-  public PersonajeServiceImpl(PersonajeRepository personajeRepository, PersonajeMapper personajeMapper) {
+  public PersonajeServiceImpl(PersonajeRepository personajeRepository, PeliculaService peliculaService, PersonajeMapper personajeMapper) {
     this.personajeRepository = personajeRepository;
+    this.peliculaService = peliculaService;
     this.personajeMapper = personajeMapper;
   }
 
@@ -58,5 +63,13 @@ public class PersonajeServiceImpl implements PersonajeService {
   @Override
   public void delete(Long id) {
     this.personajeRepository.deleteById(id);
+  }
+
+  @Override
+  public void addPelicula(Long id, Long idPelicula) {
+    PersonajeEntity entity = this.personajeRepository.getById(id);
+    PeliculaEntity peliculaEntity = this.peliculaService.getEntityById(idPelicula);
+    entity.agregarPelicula(peliculaEntity);
+    this.personajeRepository.save(entity);
   }
 }

--- a/src/main/java/com/alkemy/disney/disney/service/impl/PersonajeServiceImpl.java
+++ b/src/main/java/com/alkemy/disney/disney/service/impl/PersonajeServiceImpl.java
@@ -16,8 +16,8 @@ import java.util.Optional;
 @Service
 public class PersonajeServiceImpl implements PersonajeService {
 
-  private PersonajeRepository personajeRepository;
-  private PersonajeMapper personajeMapper;
+  private final PersonajeRepository personajeRepository;
+  private final PersonajeMapper personajeMapper;
 
   @Autowired
   public PersonajeServiceImpl(PersonajeRepository personajeRepository, PersonajeMapper personajeMapper) {

--- a/src/main/java/com/alkemy/disney/disney/service/impl/PersonajeServiceImpl.java
+++ b/src/main/java/com/alkemy/disney/disney/service/impl/PersonajeServiceImpl.java
@@ -35,8 +35,8 @@ public class PersonajeServiceImpl implements PersonajeService {
   }
 
   @Override
-  public List<PersonajeBasicDTO> getAll(String name, Integer age) {
-    PersonajeFilterDTO personajeFilterDTO = new PersonajeFilterDTO(name, age);
+  public List<PersonajeBasicDTO> getAll(String name, Integer age, List<Long> idMovies) {
+    PersonajeFilterDTO personajeFilterDTO = new PersonajeFilterDTO(name, age, idMovies);
     Specification<PersonajeEntity> spec = PersonajeSpecification.getByFilters(personajeFilterDTO);
     List<PersonajeEntity> entities = this.personajeRepository.findAll(spec);
     return personajeMapper.personajeEntityList2BasicDTOList(entities);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,3 +7,5 @@ spring.jpa.hibernate.ddl-auto=update
 # SQL
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=false
+# Override
+spring.main.allow-bean-definition-overriding=true

--- a/src/test/java/com/alkemy/disney/disney/DisneyApplicationTests.java
+++ b/src/test/java/com/alkemy/disney/disney/DisneyApplicationTests.java
@@ -6,8 +6,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class DisneyApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
+  @Test
+  void contextLoads() {
+  }
 
 }


### PR DESCRIPTION
### Feedback recibido

Por lo general al nombrar las entidades no se suele poner "Entity" al final, porque por el paquete en donde estan y las anotaciones se sobreentiende que son entidades, y queda mas legible cuando la llamas de otro lado. En cambio en el resto del codigo (controller, repository y service) si esta bueno indicar que es al final, por ej; "GeneroService", pero en caso de las entidades esta bueno que quede solamente "Genero". En caso de sacarle la palabra Entity y dejar solo "Genero" por ejemplo, deberias borrar la anotacion @Table tambien. Por que la anotacion @Entity ya te crea una tabla automaticamente con el nombre de la clase, por ende la anotacion @Table queda redundante por que lo unico que hace es renombrarla.

@GeneratedValue(strategy = GenerationType.SEQUENCE). Se deberia usar GenerationType.IDENTITY en su lugar. Es el standard por defecto para MySQL. 

En PeliculaEntity.java tenes esto: @ManyToOne(fetch = FetchType.EAGER, cascade = CascadeType.ALL) @JoinColumn(name = "genero_id", insertable = false, updatable = false) private GeneroEntity genero; @Column(name = "genero_id", nullable = false) private Long generoId; Ojo con el CascadeType.ALL porque donde elimines una pelicula tambien te va a eliminar el genero, asi que lo mejor seria ponerle MERGE. Te recomiendo investigar sobre los diferentes CascadeType y ver que hacen. 

Las relaciones que terminan en One (OneToOne y ManyToOne) tienen por defecto FetchType.EAGER asi que no deberiamos indicarselo porque queda redundante. 

Al definir el @JoinColumn(name = "genero_id") en el atributo genero ya automaticamente te crea una columna en la base de datos con ese nombre, entonces que despues mas abajo vuelvas a crear una columna con genero ahi te queda redundante, asi que habriamos que eliminarlo. Lo que si no te olvides de sacar (insertable = false, updatable = false) del JoinColumn porque no te va a andar sino

