### PR TITLE
Correccion entraga 01

### DIFF
--- a/src/main/java/com/alkemy/disney/disney/entity/Genero.java
+++ b/src/main/java/com/alkemy/disney/disney/entity/Genero.java
@@ -10,7 +10,7 @@ import javax.persistence.*;
 @Table(name = "genero")
 @Getter
 @Setter
-public class GeneroEntity {
+public class Genero {
 
   @Id
   @GeneratedValue(strategy = GenerationType.SEQUENCE)

--- a/src/main/java/com/alkemy/disney/disney/entity/Genero.java
+++ b/src/main/java/com/alkemy/disney/disney/entity/Genero.java
@@ -7,7 +7,6 @@ import lombok.Setter;
 import javax.persistence.*;
 
 @Entity
-@Table(name = "genero")
 @Getter
 @Setter
 public class Genero {

--- a/src/main/java/com/alkemy/disney/disney/entity/Genero.java
+++ b/src/main/java/com/alkemy/disney/disney/entity/Genero.java
@@ -12,7 +12,7 @@ import javax.persistence.*;
 public class Genero {
 
   @Id
-  @GeneratedValue(strategy = GenerationType.SEQUENCE)
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
   private String nombre;

--- a/src/main/java/com/alkemy/disney/disney/entity/Pelicula.java
+++ b/src/main/java/com/alkemy/disney/disney/entity/Pelicula.java
@@ -38,7 +38,7 @@ public class Pelicula {
   )
   private Set<Personaje> personajes = new HashSet<>();
 
-  @ManyToOne(fetch = FetchType.EAGER)
+  @ManyToOne
   @JoinColumn(name = "genero_id", insertable = false, updatable = false)
   private Genero genero;
 

--- a/src/main/java/com/alkemy/disney/disney/entity/Pelicula.java
+++ b/src/main/java/com/alkemy/disney/disney/entity/Pelicula.java
@@ -39,9 +39,6 @@ public class Pelicula {
   private Set<Personaje> personajes = new HashSet<>();
 
   @ManyToOne
-  @JoinColumn(name = "genero_id", insertable = false, updatable = false)
+  @JoinColumn(name = "genero_id")
   private Genero genero;
-
-  @Column(name = "genero_id", nullable = false)
-  private Long generoId;
 }

--- a/src/main/java/com/alkemy/disney/disney/entity/Pelicula.java
+++ b/src/main/java/com/alkemy/disney/disney/entity/Pelicula.java
@@ -14,7 +14,7 @@ import java.util.Set;
 @Setter
 public class Pelicula {
   @Id
-  @GeneratedValue(strategy = GenerationType.SEQUENCE)
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
   private String imagen;

--- a/src/main/java/com/alkemy/disney/disney/entity/Pelicula.java
+++ b/src/main/java/com/alkemy/disney/disney/entity/Pelicula.java
@@ -10,7 +10,6 @@ import java.util.HashSet;
 import java.util.Set;
 
 @Entity
-@Table(name = "pelicula")
 @Getter
 @Setter
 public class Pelicula {

--- a/src/main/java/com/alkemy/disney/disney/entity/Pelicula.java
+++ b/src/main/java/com/alkemy/disney/disney/entity/Pelicula.java
@@ -38,7 +38,7 @@ public class Pelicula {
   )
   private Set<Personaje> personajes = new HashSet<>();
 
-  @ManyToOne(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
+  @ManyToOne(fetch = FetchType.EAGER)
   @JoinColumn(name = "genero_id", insertable = false, updatable = false)
   private Genero genero;
 

--- a/src/main/java/com/alkemy/disney/disney/entity/Pelicula.java
+++ b/src/main/java/com/alkemy/disney/disney/entity/Pelicula.java
@@ -38,7 +38,7 @@ public class Pelicula {
   )
   private Set<Personaje> personajes = new HashSet<>();
 
-  @ManyToOne
+  @ManyToOne(cascade = CascadeType.MERGE)
   @JoinColumn(name = "genero_id")
   private Genero genero;
 }

--- a/src/main/java/com/alkemy/disney/disney/entity/Pelicula.java
+++ b/src/main/java/com/alkemy/disney/disney/entity/Pelicula.java
@@ -13,7 +13,7 @@ import java.util.Set;
 @Table(name = "pelicula")
 @Getter
 @Setter
-public class PeliculaEntity {
+public class Pelicula {
   @Id
   @GeneratedValue(strategy = GenerationType.SEQUENCE)
   private Long id;
@@ -37,11 +37,11 @@ public class PeliculaEntity {
       joinColumns = @JoinColumn(name = "pelicula_id"),
       inverseJoinColumns = @JoinColumn(name = "personaje_id")
   )
-  private Set<PersonajeEntity> personajes = new HashSet<>();
+  private Set<Personaje> personajes = new HashSet<>();
 
   @ManyToOne(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
   @JoinColumn(name = "genero_id", insertable = false, updatable = false)
-  private GeneroEntity genero;
+  private Genero genero;
 
   @Column(name = "genero_id", nullable = false)
   private Long generoId;

--- a/src/main/java/com/alkemy/disney/disney/entity/Personaje.java
+++ b/src/main/java/com/alkemy/disney/disney/entity/Personaje.java
@@ -11,7 +11,7 @@ import java.util.Set;
 @Table(name = "personaje")
 @Getter
 @Setter
-public class PersonajeEntity {
+public class Personaje {
   @Id
   @GeneratedValue(strategy = GenerationType.SEQUENCE)
   private Long id;
@@ -27,13 +27,13 @@ public class PersonajeEntity {
   private String historia;
 
   @ManyToMany(mappedBy = "personajes", cascade = CascadeType.ALL)
-  private Set<PeliculaEntity> peliculas = new HashSet<>();
+  private Set<Pelicula> peliculas = new HashSet<>();
 
-  public void agregarPelicula(PeliculaEntity pelicula) {
+  public void agregarPelicula(Pelicula pelicula) {
     this.peliculas.add(pelicula);
   }
 
-  public void eliminarPelicula(PeliculaEntity pelicula) {
+  public void eliminarPelicula(Pelicula pelicula) {
     this.peliculas.remove(pelicula);
   }
 }

--- a/src/main/java/com/alkemy/disney/disney/entity/Personaje.java
+++ b/src/main/java/com/alkemy/disney/disney/entity/Personaje.java
@@ -12,7 +12,7 @@ import java.util.Set;
 @Setter
 public class Personaje {
   @Id
-  @GeneratedValue(strategy = GenerationType.SEQUENCE)
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
   private String imagen;

--- a/src/main/java/com/alkemy/disney/disney/entity/Personaje.java
+++ b/src/main/java/com/alkemy/disney/disney/entity/Personaje.java
@@ -8,7 +8,6 @@ import java.util.HashSet;
 import java.util.Set;
 
 @Entity
-@Table(name = "personaje")
 @Getter
 @Setter
 public class Personaje {


### PR DESCRIPTION
### Feedback recibido

Por lo general al nombrar las entidades no se suele poner "Entity" al final, porque por el paquete en donde estan y las anotaciones se sobreentiende que son entidades, y queda mas legible cuando la llamas de otro lado. En cambio en el resto del codigo (controller, repository y service) si esta bueno indicar que es al final, por ej; "GeneroService", pero en caso de las entidades esta bueno que quede solamente "Genero". En caso de sacarle la palabra Entity y dejar solo "Genero" por ejemplo, deberias borrar la anotacion @Table tambien. Por que la anotacion @Entity ya te crea una tabla automaticamente con el nombre de la clase, por ende la anotacion @Table queda redundante por que lo unico que hace es renombrarla.

@GeneratedValue(strategy = GenerationType.SEQUENCE). Se deberia usar GenerationType.IDENTITY en su lugar. Es el standard por defecto para MySQL. 

En PeliculaEntity.java tenes esto: @ManyToOne(fetch = FetchType.EAGER, cascade = CascadeType.ALL) @JoinColumn(name = "genero_id", insertable = false, updatable = false) private GeneroEntity genero; @Column(name = "genero_id", nullable = false) private Long generoId; Ojo con el CascadeType.ALL porque donde elimines una pelicula tambien te va a eliminar el genero, asi que lo mejor seria ponerle MERGE. Te recomiendo investigar sobre los diferentes CascadeType y ver que hacen. 

Las relaciones que terminan en One (OneToOne y ManyToOne) tienen por defecto FetchType.EAGER asi que no deberiamos indicarselo porque queda redundante. 

Al definir el @JoinColumn(name = "genero_id") en el atributo genero ya automaticamente te crea una columna en la base de datos con ese nombre, entonces que despues mas abajo vuelvas a crear una columna con genero ahi te queda redundante, asi que habriamos que eliminarlo. Lo que si no te olvides de sacar (insertable = false, updatable = false) del JoinColumn porque no te va a andar sino

